### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 
 ## v1.3.0
 **New Features**
--  Added option `QUILL_NO_EXCEPTIONS` to disable exceptions, std::abort() is called instead of an expection. ([#16](https://github.com/odygrd/quill/issues/16))
+-  Added option `QUILL_NO_EXCEPTIONS` to disable exceptions, std::abort() is called instead of an exception. ([#16](https://github.com/odygrd/quill/issues/16))
 -  Exceptions thrown in the backend worker thread, will now call a user provided error handler callback to handle the error. ([#21](https://github.com/odygrd/quill/issues/21))
 -  Compile time checks for unsafe to copy user defined types. Non trivial user defined types must be explicitly tagged as safe to copy with the use of `QUILL_COPY_LOGGABLE;`. Otherwise they have to be formatted and passed as a string to the logger by the user. The old unsafe mode is still usable by `#define QUILL_MODE_UNSAFE` ([#20](https://github.com/odygrd/quill/issues/20))
 -  Added `QUILL_USE_BOUNDED_QUEUE`. In this mode no new queues get allocated but instead log messages get lost. Number of lost messages is reported to stderr.
@@ -100,7 +100,7 @@
 -  The log level names have been changed from `"LOG_INFO"`, `"LOG_DEBUG"`, etc to `"INFO"`, `"DEBUG"`, etc .. The default formatter string is now using `"LOG_"%(level_name)` instead of `%(level_name)` therefore there is now change in the behaviour. This change gives a lot of more flexibility to users who prefer to see e.g. `INFO` instead of `LOG_INFO` in the logs. ([#7](https://github.com/odygrd/quill/issues/7))
 -  An option has been added to append the date to the filename when using a FileHandler `quill::file_handler(filename, mode, FilenameAppend);`. ([#7](https://github.com/odygrd/quill/issues/7))
 -  It is now possible to specify the timezone of each handler timestamp. A new parameter is added to `file_handler->set_pattern(...)`. See `PatternFormatter::Timezone`. ([#7](https://github.com/odygrd/quill/issues/7))
--  Rename `emit` as it can confict with Qt macros. ([#4](https://github.com/odygrd/quill/issues/4))
+-  Rename `emit` as it can conflict with Qt macros. ([#4](https://github.com/odygrd/quill/issues/4))
 -  Upgraded `libfmt` to `6.2.0`.
 
 ## v1.0.0

--- a/README.md
+++ b/README.md
@@ -21,21 +21,21 @@
       <img src="https://img.shields.io/codefactor/grade/github/odygrd/quill?logo=codefactor&style=flat-square" alt="CodeFactor" />
      </a>
   </div>
- 
+
   <div>
-    <a href="http://opensource.org/licenses/MIT">
+    <a href="https://opensource.org/licenses/MIT">
       <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="license" />
     </a>
     <a href="https://en.wikipedia.org/wiki/C%2B%2B14">
       <img src="https://img.shields.io/badge/language-C%2B%2B14-red.svg?style=flat-square" alt="language" />
     </a>
   </div>
-  
+
   <p><b>Asynchronous Low Latency C++ Logging Library</b></p>
-  
+
 </div>
 
-  
+
 <br>
 
 -  [Introduction](#introduction)
@@ -65,9 +65,9 @@ The main goals of the library are:
 ## Features
  -  Type safe python style API with compile type checks and built-in support for logging STL types/containers by using the excellent [{fmt}](https://github.com/fmtlib/fmt) library.
  -  Blazing fast. See [Benchmarks](https://github.com/odygrd/quill#performance).
- -  Formatting is performed outside of the hot-path in a backend logging thread. For `non-built-in` types `ostream::operator<<()` is called on a copy of the object by the backend logging thread. Unsafe to copy `non-trivial user defined` are detected in compile time. Those types can be tagged as `safe-to-copy` to avoid formatting them on the hot path. See [User Defined Types](https://github.com/odygrd/quill/wiki/5.-User-Defined-Types).
+ -  Formatting is performed outside of the hot-path in a backend logging thread. For `non-built-in` types `ostream::operator<<()` is called on a copy of the object by the backend logging thread. Unsafe to copy `non-trivial user defined` are detected in compile time. Those types can be tagged as `safe-to-copy` to avoid formatting them on the hot path. See [User Defined Types](https://github.com/odygrd/quill/wiki/8.-User-Defined-Types).
  -  Log levels can be completely stripped out at compile time reducing `if` branches.
- -  Custom logs formatting. Logs can be formatted based on a user specified pattern. See [Formatters](https://github.com/odygrd/quill/wiki/3.-Formatters).
+ -  Custom logs formatting. Logs can be formatted based on a user specified pattern. See [Formatters](https://github.com/odygrd/quill/wiki/4.-Formatters).
  -  Log statements always appear in timestamp order even if produced by different threads. This makes debugging easier in multi-threaded applications.
  -  Backtrace logging. Store log messages in a ring buffer and display later when a higher severity log statement occurs or on demand. See [Backtrace Logging](https://github.com/odygrd/quill/wiki/6.-Backtrace-Logging).
  -  `guaranteed non-blocking` or `non-guaranteed` logging. In `guaranteed non-blocking` logging more memory is allocated so the caller doesn't get blocked, log messages are never dropped. In `non-guaranteed` mode there is no heap allocation log messages can be dropped. See [FAQ](https://github.com/odygrd/quill/wiki/7.-FAQ#guaranteed-logging-mode).
@@ -77,12 +77,12 @@ The main goals of the library are:
     -  File Logging
     -  Rotating log files
     -  Time rotating log files
- -  Filters for filtering log messages. See [Filters](https://github.com/odygrd/quill/wiki/3.-Filters). 
+ -  Filters for filtering log messages. See [Filters](https://github.com/odygrd/quill/wiki/3.-Filters).
  -  Clean warning-free codebase even on high warning levels.
 
 ## Performance
-The following message is logged 2'000'000 times per thread  ```LOG_INFO(logger, "Logging int: {}, int: {}, double: {}", i, j, d)```.  
-Results are in `nanoseconds`.  
+The following message is logged 2'000'000 times per thread  ```LOG_INFO(logger, "Logging int: {}, int: {}, double: {}", i, j, d)```.
+Results are in `nanoseconds`.
 
 #### 1 Thread
 
@@ -112,7 +112,7 @@ Results are in `nanoseconds`.
 
 The benchmarks are done on `Linux (Ubuntu/RHEL)` with GCC 9.1.
 
-Each thread is pinned on a different cpu.  
+Each thread is pinned on a different cpu.
 Running the backend logger thread in the same CPU as the caller hot-path threads, slows down the log message processing on the backend logging thread and will cause the SPSC queue to fill faster and re-allocate.
 
 Continuously Logging messages in a loop makes the consumer (backend logging thread) unable to follow up and the queue will have to re-allocate or block for most logging libraries expect very high throughput binary loggers like PlatformLab Nanolog.
@@ -124,15 +124,15 @@ Therefore, a different approach was followed that suits more to a real time appl
 
 I run each logger benchmark four times and the above latencies are the second best result.
 
-The benchmark code can be found [here](https://github.com/odygrd/logger_benchmarks).  
-More benchmarks results (bench_results_*.txt) can be found [here](https://github.com/odygrd/logger_benchmarks).
+The benchmark code can be found [here](https://github.com/odygrd/logger_benchmarks).
+More benchmarks results (`bench_results_*.txt`) can be found [here](https://github.com/odygrd/logger_benchmarks).
 
 ### Verdict
-If you want to use a `printf` API and only log primitive types, `PlatformLab NanoLog` is the fastest logger with the lowest latencies and high throughput when we look at 99th percentile. 
+If you want to use a `printf` API and only log primitive types, `PlatformLab NanoLog` is the fastest logger with the lowest latencies and high throughput when we look at 99th percentile.
 However :
 1) Need to decompress a binary log file to read log each time.
 2) Need to specify the type we are logging for each call to the logger.
-3) To log any user defined type or a something like ```std::vector``` via `NanoLog` you would first have to convert it to a string in the hot path.  Instead, Quill copies the object and covertion to string is performed by the backend thread.
+3) To log any user defined type or a something like `std::vector` via `NanoLog` you would first have to convert it to a string in the hot path.  Instead, Quill copies the object and covertion to string is performed by the backend thread.
 
 `Quill` backend is not as high throughput as `NanoLog` as it doesn't log binary. In terms of latency it is almost as fast as `Nanolog`. `Quill` is much more feature rich offering custom formatting, several logger objects, human readable log files and a superior format API that also supports user-defined types.
 
@@ -143,12 +143,12 @@ Cygwin is not supported at the moment.
 | Compiler  | Notes            |
 |-----------|------------------|
 | GCC       | version >= 5.0   |
-| Clang     | version >= 5.0   |      
+| Clang     | version >= 5.0   |
 | MSVC++    | version >= 14.3  |
 
-| Platform  | Notes                                                   |
-|-----------|---------------------------------------------------------|
-| Linux     | Ubuntu, RHEL, Centos, Fedora                   |                                                    |
+| Platform  | Notes                                          |
+|-----------|------------------------------------------------|
+| Linux     | Ubuntu, RHEL, Centos, Fedora                   |
 | Windows   | Windows 10 - version 1607, Windows Server 2016 |
 | macOS     | Tested with Xcode 9.4                          |
 
@@ -243,7 +243,7 @@ my_project/
 cmake_minimum_required(VERSION 3.1.0)
 project(my_project)
 
-set(CMAKE_CXX_STANDARD 14) 
+set(CMAKE_CXX_STANDARD 14)
 
 add_subdirectory(quill)
 
@@ -259,11 +259,11 @@ Advanced usage and additional documentation can be found in the [wiki](https://g
 The [examples](https://github.com/odygrd/quill/tree/master/examples) folder is also a good source of documentation.
 
 ## License
-Quill is licensed under the [MIT License](http://opensource.org/licenses/MIT)
+Quill is licensed under the [MIT License](https://opensource.org/licenses/MIT)
 
-Quill depends on third party libraries with separate copyright notices and license terms. 
+Quill depends on third party libraries with separate copyright notices and license terms.
 Your use of the source code for these subcomponents is subject to the terms and conditions of the following licenses.
 
-   - ([MIT License](http://opensource.org/licenses/MIT)) {fmt} (https://github.com/fmtlib/fmt/blob/master/LICENSE.rst)
-   - ([MIT License](http://opensource.org/licenses/MIT)) invoke.hpp (https://github.com/BlackMATov/invoke.hpp/blob/master/LICENSE.md)
-   - ([MIT License](http://opensource.org/licenses/MIT)) doctest (https://github.com/onqtam/doctest/blob/master/LICENSE.txt)
+   - ([MIT License](https://opensource.org/licenses/MIT)) {fmt} (https://github.com/fmtlib/fmt/blob/master/LICENSE.rst)
+   - ([MIT License](https://opensource.org/licenses/MIT)) invoke.hpp (https://github.com/BlackMATov/invoke.hpp/blob/master/LICENSE.md)
+   - ([MIT License](https://opensource.org/licenses/MIT)) doctest (https://github.com/onqtam/doctest/blob/master/LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The main goals of the library are:
 -  **Convenience** Ease application monitoring/debugging. Latency is equal to latencies of binary loggers, but the produced log is in human readable form.
 
 ## Features
- -  Type safe python style API with compile type checks and build-in support for logging STL types/containers by using the excellent [{fmt}](https://github.com/fmtlib/fmt) library.
+ -  Type safe python style API with compile type checks and built-in support for logging STL types/containers by using the excellent [{fmt}](https://github.com/fmtlib/fmt) library.
  -  Blazing fast. See [Benchmarks](https://github.com/odygrd/quill#performance).
  -  Formatting is performed outside of the hot-path in a backend logging thread. For `non-built-in` types `ostream::operator<<()` is called on a copy of the object by the backend logging thread. Unsafe to copy `non-trivial user defined` are detected in compile time. Those types can be tagged as `safe-to-copy` to avoid formatting them on the hot path. See [User Defined Types](https://github.com/odygrd/quill/wiki/5.-User-Defined-Types).
  -  Log levels can be completely stripped out at compile time reducing `if` branches.

--- a/examples/example_user_defined_types.cpp
+++ b/examples/example_user_defined_types.cpp
@@ -61,7 +61,7 @@ int main()
   // The following fails to compile
   // LOG_INFO(quill::get_logger(), "The user is {}", usr);
 
-  // The user has to explictly format on the hot path, or instead tag the object (see User2)
+  // The user has to explicitly format on the hot path, or instead tag the object (see User2)
   LOG_INFO(quill::get_logger(), "The user is {}", quill::utility::to_string(usr));
 
   // The following compiles and logs, because the object is tagged by the user as safe

--- a/quill/include/quill/PatternFormatter.h
+++ b/quill/include/quill/PatternFormatter.h
@@ -134,7 +134,7 @@ private:
   /** Public classes **/
 public:
   /**
-   * Stores the precission of the timestamp
+   * Stores the precision of the timestamp
    */
   enum class TimestampPrecision : uint8_t
   {
@@ -316,13 +316,13 @@ private:
    * Process part of the pattern and create a helper formatter class
    * @param format_pattern_part format pattern part
    * @throws on invalid input
-   * @return a formater helper base
+   * @return a formatter helper base
    */
   template <size_t N>
   QUILL_NODISCARD std::unique_ptr<FormatterHelperBase> _make_formatter_helper(std::string const& format_pattern_part);
 
   /**
-   * Given a message part generate a vector of callbacks in the excact same order as the format
+   * Given a message part generate a vector of callbacks in the exact same order as the format
    * specifiers in the pattern format string
    * @param pattern pattern
    */

--- a/quill/include/quill/Quill.h
+++ b/quill/include/quill/Quill.h
@@ -131,7 +131,7 @@ QUILL_NODISCARD QUILL_ATTRIBUTE_COLD Handler* time_rotating_file_handler(
  * @param base_filename the base file name
  * @param mode file mode to open file
  * @param max_bytes The max_bytes of the file, when the size is exceeded the file witll rollover
- * @param backup_count The maxinum number of times we want to rollover
+ * @param backup_count The maximum number of times we want to rollover
  * @return a pointer to a rotating file handler
  */
 QUILL_NODISCARD QUILL_ATTRIBUTE_COLD Handler* rotating_file_handler(filename_t const& base_filename,
@@ -317,7 +317,7 @@ QUILL_ATTRIBUTE_COLD void set_backend_thread_name(std::string const& name);
  * The backend thread will always "busy wait" spinning around every caller thread's local spsc queue.
  *
  * The reason for this is to reduce latency on the caller thread as notifying the
- * backend thread even by a fast backed by atomics semaphone would add additional latency
+ * backend thread even by a fast backed by atomics semaphore would add additional latency
  * to the caller thread.
  * The alternative to this is letting the backend thread "busy wait" and at the same time reduce the backend thread's
  * OS scheduler priority by a periodic call to sleep().

--- a/quill/include/quill/TweakMe.h
+++ b/quill/include/quill/TweakMe.h
@@ -101,7 +101,7 @@
  * There is a convenience macro also `QUILL_COPY_LOGGABLE`
  *
  * If the user defined type has shared mutable references to other objects as class members
- * this tag should not be provided, instead the formatting should be done explictly on the caller
+ * this tag should not be provided, instead the formatting should be done explicitly on the caller
  * thread side by the user.
  *
  * QUILL_MODE_UNSAFE is not recommended as the user should be never careful when logging user

--- a/quill/include/quill/Utility.h
+++ b/quill/include/quill/Utility.h
@@ -21,7 +21,7 @@ namespace utility
  * Formats the given buffer to hex
  * @param buffer input buffer
  * @param size input buffer size
- * @return A string containing the hexadecimal representation of the givven buffer
+ * @return A string containing the hexadecimal representation of the given buffer
  */
 QUILL_NODISCARD std::string to_hex(unsigned char* buffer, size_t size) noexcept;
 QUILL_NODISCARD std::string to_hex(unsigned char const* buffer, size_t size) noexcept;
@@ -30,7 +30,7 @@ QUILL_NODISCARD std::string to_hex(unsigned char const* buffer, size_t size) noe
  * Formats the given buffer to hex
  * @param buffer input buffer
  * @param size input buffer size
- * @return A string containing the hexadecimal representation of the givven buffer
+ * @return A string containing the hexadecimal representation of the given buffer
  */
 QUILL_NODISCARD std::string to_hex(char* buffer, size_t size) noexcept;
 QUILL_NODISCARD std::string to_hex(char const* buffer, size_t size) noexcept;
@@ -38,7 +38,7 @@ QUILL_NODISCARD std::string to_hex(char const* buffer, size_t size) noexcept;
 /**
  * By default the logger will take a copy of the passed object and then will call the operator<< in the background thread
  * Use this function when :
- * 1) [to print a non copiable] It is not possible to take a copy of an object when the object is not copyable
+ * 1) [to print a non copyable] It is not possible to take a copy of an object when the object is not copyable
  * 2) [to avoid race condition] You want to log a class that contains a reference or a pointer to another object as a class member, that
  * can be updated before the logger thread calls operator<<. In that case when the logger
  * thread tries to call operator<< on the class itself but the internal reference object might have changed between the

--- a/quill/include/quill/detail/ThreadContext.h
+++ b/quill/include/quill/detail/ThreadContext.h
@@ -51,7 +51,7 @@ public:
    * This object should always be aligned to a cache line as it contains the SPSC queue as a member
    * which has cache line alignment requirements
    * @param i size of object
-   * @return a pointer to the allcoated object
+   * @return a pointer to the allocated object
    */
   void* operator new(size_t i) { return aligned_alloc(CACHELINE_SIZE, i); }
 

--- a/quill/include/quill/detail/events/BacktraceEvent.h
+++ b/quill/include/quill/detail/events/BacktraceEvent.h
@@ -60,7 +60,7 @@ public:
   {
     if (_backtrace_capacity != std::numeric_limits<uint32_t>::max())
     {
-      // If the _backtrace_capacity is set it means we are seting up the backtrace
+      // If the _backtrace_capacity is set it means we are setting up the backtrace
       // We setup the backtrace like this with an event to the backend thread - that way we avoid any overcomplications
       backtrace_log_record_storage.set_capacity(_logger_details->name(), _backtrace_capacity);
     }

--- a/quill/include/quill/detail/events/LogRecordEvent.h
+++ b/quill/include/quill/detail/events/LogRecordEvent.h
@@ -88,7 +88,7 @@ public:
 
   /**
    * Process a backtrace record and forward it to all handlers
-   * @param thread_id The thread id that initialised the original record. This is stored and provided seperately.
+   * @param thread_id The thread id that initialised the original record. This is stored and provided separately.
    * @param timestamp_callback A callback to obtain the real timestamp of the record
    */
   void backend_process_backtrace_log_record(char const* thread_id, GetHandlersCallbackT const&,

--- a/quill/include/quill/detail/misc/FreeListAllocator.h
+++ b/quill/include/quill/detail/misc/FreeListAllocator.h
@@ -228,7 +228,7 @@ protected:
   /**
    * Free list structure. Blocks are added to the free list on the `free` operation.
    * Consequent allocations of the appropriate size reuse the freed blocks.
-   * If a std::map or std::multimap is used they call operator::new everytime
+   * If a std::map or std::multimap is used they call operator::new every time
    * an insertion happens to allocate a free node, so a std::vector is used instead.
    */
   std::vector<size_blocks_pair_t> _free_list;

--- a/quill/include/quill/detail/misc/Os.h
+++ b/quill/include/quill/detail/misc/Os.h
@@ -70,7 +70,7 @@ QUILL_NODISCARD QUILL_ATTRIBUTE_COLD uint32_t get_thread_id() noexcept;
 QUILL_NODISCARD QUILL_ATTRIBUTE_COLD uint32_t get_process_id() noexcept;
 
 /**
- * Get's the page size
+ * Gets the page size
  * @return the size of the page
  */
 QUILL_NODISCARD QUILL_ATTRIBUTE_COLD size_t get_page_size() noexcept;

--- a/quill/include/quill/detail/misc/RdtscClock.h
+++ b/quill/include/quill/detail/misc/RdtscClock.h
@@ -52,7 +52,7 @@ public:
 
   /**
    * Convert tsc cycles to nanoseconds
-   * @param rdtsc_value the rdtsc timestamp to conver
+   * @param rdtsc_value the rdtsc timestamp to convert
    * @return the rdtsc timestamp converted to nanoseconds since epoch
    */
   std::chrono::nanoseconds time_since_epoch(uint64_t rdtsc_value) const noexcept;

--- a/quill/include/quill/detail/misc/Utilities.h
+++ b/quill/include/quill/detail/misc/Utilities.h
@@ -131,7 +131,7 @@ QUILL_NODISCARD time_t next_noon_or_midnight_timestamp(time_t timestamp, Timezon
  * @param format_string The format string to pass to strftime
  * @param timestamp The timestamp
  * @param timezone local time or gmtime
- * @return the formated string as vector of characters
+ * @return the formatted string as vector of characters
  */
 QUILL_NODISCARD std::vector<char> safe_strftime(char const* format_string, time_t timestamp, Timezone timezone);
 

--- a/quill/src/detail/ThreadContextCollection.cpp
+++ b/quill/src/detail/ThreadContextCollection.cpp
@@ -17,7 +17,7 @@ ThreadContextCollection::ThreadContextWrapper::ThreadContextWrapper(ThreadContex
   // We can not use std::make_shared above.
   // Explanation :
   // ThreadContext has the SPSC queue as a class member which requires a 64 cache byte alignment,
-  // since we are creating this object on the heap this is not guaranted.
+  // since we are creating this object on the heap this is not guaranteed.
   // Visual Studio is the only compiler that gives a warning that ThreadContext might not be aligned to 64 bytes,
   // as it is allocated on the heap and we should use aligned alloc instead.
   // The solution to solve this would be to define a custom operator new and operator delete for ThreadContext.

--- a/quill/test/FreeListAllocatorTest.cpp
+++ b/quill/test/FreeListAllocatorTest.cpp
@@ -685,7 +685,7 @@ TEST_CASE("allocate_deallocate_many_from_os")
   allocated_ptrs.clear();
 
   // We will allocate again but this time MEMORY_S / 2
-  // This can fit and split the MEMORY_S blokcs we had allocated initialy
+  // This can fit and split the MEMORY_S blocks we had allocated initially
   for (size_t i = 0; i < ITERATIONS; ++i)
   {
     // request num blocks of memory of size memory_s

--- a/quill/test/LoggerCollectionTest.cpp
+++ b/quill/test/LoggerCollectionTest.cpp
@@ -78,7 +78,7 @@ TEST_CASE("get_non_existing_logger")
 /***/
 TEST_CASE("default_logger")
 {
-  // Get the default logger and change the log level, then get the default logger again ans check
+  // Get the default logger and change the log level, then get the default logger again and check
   // the values we set are cached
   Config cfg;
   HandlerCollection hc;

--- a/quill/test/RecordTest.cpp
+++ b/quill/test/RecordTest.cpp
@@ -24,12 +24,12 @@ TEST_CASE("construct")
 
   LoggerDetails logger_details{"default", hc.stdout_console_handler()};
   {
-    // test with char const the tuple get's promoted
+    // test with char const the tuple gets promoted
     using record_t = LogRecordEvent<is_backtrace_log_record, mock_log_record_info, int, double, char const*>;
     static_assert(std::is_same<record_t::PromotedTupleT, std::tuple<int, double, std::string>>::value,
                   "tuple is not promoted");
 
-    // Try to contruct one using the same args
+    // Try to construct one using the same args
     record_t msg{&logger_details, 1337, 13.5, "test"};
 
     // Check that the constructed msg has a promoted underlying tuple
@@ -44,7 +44,7 @@ TEST_CASE("construct")
     static_assert(std::is_same<record_t::PromotedTupleT, std::tuple<int, double, std::string>>::value,
                   "tuple is not promoted");
 
-    // Try to contruct one using the same args
+    // Try to construct one using the same args
     record_t msg(&logger_details, 1337, 13.5, test_char);
 
     // Check that the constructed msg has a promoted underlying tuple


### PR DESCRIPTION
I found and fixed some typos with [codespell](https://github.com/codespell-project/codespell).