### PR TITLE
Fix warning when compiling with clang on macOS

### DIFF
--- a/quill/src/detail/misc/StringFromTime.cpp
+++ b/quill/src/detail/misc/StringFromTime.cpp
@@ -188,7 +188,7 @@ std::string const& StringFromTime::format_timestamp(time_t timestamp)
 
   std::string to_replace;
 
-  for (auto const index : _cached_indexes)
+  for (auto const& index : _cached_indexes)
   {
     // for each cached index we have, replace it when the new value
     switch (index.second)


### PR DESCRIPTION
Fixes the following warning when compiling with clang 11/12 on macOS:
```
[11/29] Building CXX object quill/CMakeFiles/quill.dir/src/detail/misc/StringFromTime.cpp.o
../quill/src/detail/misc/StringFromTime.cpp:191:19: warning: loop variable 'index' of type 'const std::__1::pair<unsigned long, quill::detail::StringFromTime::format_type>' creates a copy from type 'const std::__1::pair<unsigned long, quill::detail::StringFromTime::format_type>' [-Wrange-loop-analysis]
  for (auto const index : _cached_indexes)
                  ^
../quill/src/detail/misc/StringFromTime.cpp:191:8: note: use reference type 'const std::__1::pair<unsigned long, quill::detail::StringFromTime::format_type> &' to prevent copying
  for (auto const index : _cached_indexes)
       ^~~~~~~~~~~~~~~~~~
                  &
1 warning generated.
```