### PR TITLE
fix WIN32 compilation error when NOMINMAX is already defined

### DIFF
--- a/quill/include/quill/bundled/fmt/chrono.h
+++ b/quill/include/quill/bundled/fmt/chrono.h
@@ -294,7 +294,7 @@ inline std::tm localtime(std::time_t time) {
     std::time_t time_;
     std::tm tm_;
 
-    dispatcher(std::time_t t) : time_(t) {}
+    dispatcher(std::time_t t) : time_(t), tm_() {}
 
     bool run() {
       using namespace fmt::detail;
@@ -336,7 +336,7 @@ inline std::tm gmtime(std::time_t time) {
     std::time_t time_;
     std::tm tm_;
 
-    dispatcher(std::time_t t) : time_(t) {}
+    dispatcher(std::time_t t) : time_(t), tm_() {}
 
     bool run() {
       using namespace fmt::detail;

--- a/quill/src/detail/misc/Os.cpp
+++ b/quill/src/detail/misc/Os.cpp
@@ -15,7 +15,7 @@
 #if defined(_WIN32)
   #define WIN32_LEAN_AND_MEAN
 
-  #if !defined(__MINGW64__) || !defined(__MINGW32__)
+  #if !defined(NOMINMAX)
     // Mingw already defines this, so no need to redefine
     #define NOMINMAX
   #endif


### PR DESCRIPTION
also include a minor fix: initialise dispatcher::tm_ in chrono.h