### PR TITLE
Add missing header needed for recent versions of fmt

### DIFF
--- a/quill/include/quill/Fmt.h
+++ b/quill/include/quill/Fmt.h
@@ -12,6 +12,7 @@
  * By default Quill includes it's bundled copy.
  */
 #if defined(QUILL_FMT_EXTERNAL)
+  #include <fmt/args.h>
   #include <fmt/chrono.h>
   #include <fmt/format.h>
   #include <fmt/ostream.h>


### PR DESCRIPTION
(Thanks for the nice library btw).

In recent versions of `fmtlib/fmt`, types related to argument storage moved to `fmt/args.h` to make the core header leaner. The undefined references to `dynamic_arg_storage` are fixed with this change when using a more recent fmt library as an external dependency.