### PR TITLE
SetThreadDescription() API is not supported on older windows servers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ option(QUILL_USE_VALGRIND "Use valgrind as the default memcheck tool in CTest (R
 
 option(QUILL_ENABLE_INSTALL "Enable CMake Install when Quill is not a master project" OFF)
 
+option(QUILL_NO_THREAD_NAME_SUPPORT "Disable not supported features on windows 2012/2016" OFF)
+
 #-------------------------------------------------------------------------------------------------------
 # Use newer policies if possible, up to most recent tested version of CMake.
 #-------------------------------------------------------------------------------------------------------
@@ -127,9 +129,14 @@ if (QUILL_FMT_EXTERNAL)
     add_definitions(-DQUILL_FMT_EXTERNAL)
 endif ()
 
+if (QUILL_NO_THREAD_NAME_SUPPORT)
+    add_definitions(-DQUILL_NO_THREAD_NAME_SUPPORT)
+endif ()
+
 message(STATUS "QUILL_NO_EXCEPTIONS: " ${QUILL_NO_EXCEPTIONS})
 message(STATUS "QUILL_USE_BOUNDED_QUEUE: " ${QUILL_USE_BOUNDED_QUEUE})
 message(STATUS "QUILL_FMT_EXTERNAL: " ${QUILL_FMT_EXTERNAL})
+message(STATUS "QUILL_NO_THREAD_NAME_SUPPORT: " ${QUILL_NO_THREAD_NAME_SUPPORT})
 
 # address sanitizer flags
 if (QUILL_SANITIZE_ADDRESS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ option(QUILL_USE_VALGRIND "Use valgrind as the default memcheck tool in CTest (R
 
 option(QUILL_ENABLE_INSTALL "Enable CMake Install when Quill is not a master project" OFF)
 
-option(QUILL_NO_THREAD_NAME_SUPPORT "Disable not supported features on windows 2012/2016" OFF)
+option(QUILL_NO_THREAD_NAME_SUPPORT "Disable features that are not supported on Windows 2012/2016" OFF)
 
 #-------------------------------------------------------------------------------------------------------
 # Use newer policies if possible, up to most recent tested version of CMake.

--- a/quill/src/detail/misc/Os.cpp
+++ b/quill/src/detail/misc/Os.cpp
@@ -153,7 +153,7 @@ void set_cpu_affinity(uint16_t cpu_id)
 /***/
 void set_thread_name(char const* name)
 {
-#if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__)
+  #if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(QUILL_NO_THREAD_NAME_SUPPORT)
   // Disabled on MINGW / Cygwin.
   (void)name;
 #elif defined(_WIN32)
@@ -186,7 +186,7 @@ void set_thread_name(char const* name)
 /***/
 std::string get_thread_name()
 {
-#if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__)
+#if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(QUILL_NO_THREAD_NAME_SUPPORT)
   // Disabled on MINGW / Cygwin.
   return std::string{};
 #elif defined(_WIN32)

--- a/quill/src/detail/misc/Os.cpp
+++ b/quill/src/detail/misc/Os.cpp
@@ -153,7 +153,7 @@ void set_cpu_affinity(uint16_t cpu_id)
 /***/
 void set_thread_name(char const* name)
 {
-  #if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(QUILL_NO_THREAD_NAME_SUPPORT)
+#if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(QUILL_NO_THREAD_NAME_SUPPORT)
   // Disabled on MINGW / Cygwin.
   (void)name;
 #elif defined(_WIN32)

--- a/quill/test/UtilitiesTest.cpp
+++ b/quill/test/UtilitiesTest.cpp
@@ -100,7 +100,11 @@ TEST_CASE("safe_strftime_empty")
 TEST_CASE("set_get_thread_name")
 {
   std::thread t1{[](){
-    std::string const tname {"test_thread"};
+#ifdef QUILL_NO_THREAD_NAME_SUPPORT
+    std::string const tname{};
+#else
+    std::string const tname{"test_thread"};
+#endif
     set_thread_name(tname.data());
     std::string const res = get_thread_name();
     REQUIRE_EQ(tname, res);


### PR DESCRIPTION
Add QUILL_NO_THREAD_NAME_SUPPORT CMAKE build option to prevent usage of SetThreadDescription API

Use of SetThreadDescription() only works in Windows 2019 server.

Issue (#113)