### PR TITLE
Fix PatternFormatter.h usage of fmt::format_to for -std=c++20.

### DIFF
--- a/quill/include/quill/PatternFormatter.h
+++ b/quill/include/quill/PatternFormatter.h
@@ -120,8 +120,9 @@ private:
       // lambda expand the stored tuple arguments
       auto format_buffer = [this, &memory_buffer, timestamp, thread_id, thread_name, logger_name,
                             logline_info](auto... tuple_args) {
-        fmt::format_to(std::back_inserter(memory_buffer), _fmt_pattern.data(),
-                       tuple_args(timestamp, thread_id, thread_name, logger_name, logline_info)...);
+        fmt::vformat_to(std::back_inserter(memory_buffer), _fmt_pattern.data(),
+                        fmt::make_format_args(tuple_args(timestamp, thread_id, thread_name,
+                                                         logger_name, logline_info)...));
       };
 
       invoke_hpp::apply(format_buffer, _tuple_of_callbacks);
@@ -393,7 +394,8 @@ void PatternFormatter::format(std::chrono::nanoseconds timestamp, const char* th
                                            logger_name, logline_info);
 
   // Format the user requested string
-  fmt::format_to(std::back_inserter(_formatted_log_record), logline_info.message_format(), args...);
+  fmt::vformat_to(std::back_inserter(_formatted_log_record), logline_info.message_format(),
+                  fmt::make_format_args(args...));
 
   // Format part 3 of the pattern
   _pattern_formatter_helper_part_3->format(_formatted_log_record, timestamp, thread_id, thread_name,
@@ -417,7 +419,8 @@ typename std::enable_if_t<!detail::any_is_same<std::wstring, void, Args...>::val
                                            logger_name, logline_info);
 
   // Format the user requested string
-  fmt::format_to(std::back_inserter(_formatted_log_record), logline_info.message_format(), args...);
+  fmt::vformat_to(std::back_inserter(_formatted_log_record), logline_info.message_format(),
+                  fmt::make_format_args(args...));
 
   // Format part 3 of the pattern
   _pattern_formatter_helper_part_3->format(_formatted_log_record, timestamp, thread_id, thread_name,
@@ -445,7 +448,7 @@ typename std::enable_if_t<detail::any_is_same<std::wstring, void, Args...>::valu
 
   // Format the whole message to a wide buffer
   _w_memory_buffer.clear();
-  fmt::format_to(std::back_inserter(_w_memory_buffer), w_message_format, args...);
+  fmt::vformat_to(std::back_inserter(_w_memory_buffer), w_message_format, fmt::make_format_args(args...));
 
   // Convert the results to UTF-8
   detail::wstring_to_utf8(_w_memory_buffer, _formatted_log_record);


### PR DESCRIPTION
Should address https://github.com/odygrd/quill/issues/135

Tested on: 
- [x] Linux
- [x] MacOS
- [x] FreeBSD
- [x] Windows

With: 
- [x] gcc 11
- [x] gcc 12 (experimental), 
- [x] clang 13/14
- [ ] msvc
