### PR TITLE
Replacing QUILL_DUAL_QUEUE_MODE with QUILL_DISABLE_DUAL_QUEUE_MODE

### DIFF
--- a/quill/include/quill/Logger.h
+++ b/quill/include/quill/Logger.h
@@ -118,7 +118,7 @@ public:
     return log_statement_level >= log_level();
   }
 
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
   /**
    * Push a log record event to the spsc queue to be logged by the backend thread.
    * One spsc queue per caller thread. This function is enabled only when all arguments are
@@ -195,12 +195,12 @@ public:
    * @note This function is thread-safe.
    * @param fmt_args format arguments
    */
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
   template <bool TryFastQueue, bool IsBackTraceLogRecord, typename TLogMacroMetadata, typename TFormatString, typename... FmtArgs>
   QUILL_ALWAYS_INLINE_HOT std::enable_if_t<!detail::is_all_serializable<FmtArgs...>::value || IsBackTraceLogRecord || !TryFastQueue, void> log(
     TFormatString format_string, FmtArgs&&... fmt_args)
 #else
-  // If the QUILL_DUAL_QUEUE_MODE is not enabled, this is always enabled
+  // If the dual queue mode is not enabled, this is always enabled
   template <bool TryFastQueue, bool IsBackTraceLogRecord, typename TLogMacroMetadata, typename TFormatString, typename... FmtArgs>
   QUILL_ALWAYS_INLINE_HOT void log(TFormatString format_string, FmtArgs&&... fmt_args)
 #endif

--- a/quill/include/quill/TweakMe.h
+++ b/quill/include/quill/TweakMe.h
@@ -210,9 +210,9 @@
  *
  * Each log statement is pushed either to the first OR to the second queue.
  *
- * When QUILL_DUAL_QUEUE_MODE is disabled everything is pushed into the first queue.
+ * When dual queue mode is disabled everything is pushed into the first queue.
  *
- * When QUILL_DUAL_QUEUE_MODE is enabled any log statements that have all their arguments satisfying
+ * When dual queue mode is enabled any log statements that have all their arguments satisfying
  * the below criteria will get pushed to the second queue resulting in better performance and less allocations
  * a) fundamental types
  * b) enums
@@ -223,19 +223,19 @@
  * LOG_INFO(logger, "{} {} {}", 1, "test", std::array<int,3>{1,2,3}); -> This is pushed to the first queue (EVENT) as it contains a complex type
  *
  * NOTE:
- * 1) Using QUILL_DUAL_QUEUE_MODE with unbounded queue is the recommended option.
+ * 1) Using dual queue mode with unbounded queue is the recommended option.
  *  The difference of bounded and unbounded queues is very small in latency and the unbounded queue is
  *  safer as no log messages will get dropped.
  *
- * 2) Using QUILL_DUAL_QUEUE_MODE + QUILL_USE_BOUNDED_QUEUE will give the fastest performance possible.
+ * 2) Using dual queue mode + QUILL_USE_BOUNDED_QUEUE will give the fastest performance possible.
  * Logging only fundamental types or strings (like a printf only API) in the hot path is also recommended if you care about every nanosecond of latency.
  *
- * 3) Disable QUILL_DUAL_QUEUE_MODE if
+ * 3) Disable dual queue mode if
  * a) Don't care about around 2-10 extra nanoseconds of latency when logging just fundamental types
  * b) Mostly logging complex types, user defined types etc
  * c) A few extra ms during program initialization time are important
  */
-#define QUILL_DUAL_QUEUE_MODE
+// #define QUILL_DISABLE_DUAL_QUEUE_MODE
 
 /**
  * Quill uses a unbounded SPSC queue per spawned thread to forward the LogRecords to the backend thread.
@@ -250,7 +250,7 @@
  * The queue size can be increased or decreased based on the user needs. This queue will be shared
  * between two threads and it should not exceed the size of LLC cache.
  *
- * When QUILL_DUAL_QUEUE_MODE is used this affects the size of both queues.
+ * When dual queue mode is used this affects the size of both queues.
  *
  * @warning The configured queue size needs to be in bytes, it MUST be a power of two and a multiple
  * of the page size (4096).

--- a/quill/include/quill/detail/ThreadContext.h
+++ b/quill/include/quill/detail/ThreadContext.h
@@ -79,7 +79,7 @@ public:
     return _event_spsc_queue;
   }
 
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
   /**
    * In this queue we store only log statements that contain 100% of built-in types
    * @return A reference to the fast single-producer-single-consumer queue
@@ -146,7 +146,7 @@ public:
 #endif
 
 private:
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
   RawSPSCQueueT _raw_spsc_queue; /** queue for this thread, only log statements with POD types are here */
 #endif
 

--- a/quill/include/quill/detail/backend/BackendWorker.h
+++ b/quill/include/quill/detail/backend/BackendWorker.h
@@ -118,7 +118,7 @@ private:
   QUILL_ATTRIBUTE_HOT inline void _populate_priority_queue(
     ThreadContextCollection::backend_thread_contexts_cache_t const& cached_thread_contexts);
 
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
   /**
    * Deserialize an log message from the raw SPSC queue and emplace them to priority queue
    */
@@ -334,7 +334,7 @@ void BackendWorker::_populate_priority_queue(ThreadContextCollection::backend_th
     // read the generic event queue
     _read_event_queue(thread_context);
 
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
     // read the fast raw spsc queue
     _deserialize_raw_queue(thread_context);
 #endif
@@ -359,7 +359,7 @@ void BackendWorker::_read_event_queue(ThreadContext* thread_context)
   }
 }
 
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
 /***/
 void BackendWorker::_deserialize_raw_queue(ThreadContext* thread_context)
 {

--- a/quill/src/detail/ThreadContextCollection.cpp
+++ b/quill/src/detail/ThreadContextCollection.cpp
@@ -146,7 +146,7 @@ void ThreadContextCollection::_remove_shared_invalidated_thread_context(ThreadCo
   assert(thread_context_it->get()->event_spsc_queue().empty() &&
          "Attempting to remove a thread context with a non empty queue");
 
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
   assert(thread_context_it->get()->raw_spsc_queue().empty() &&
          "Attempting to remove a thread context with a non empty queue");
 #endif
@@ -166,7 +166,7 @@ void ThreadContextCollection::_find_and_remove_invalidated_thread_contexts()
   // If the thread context is invalid it means the thread that created it has now died.
   // We also want to empty the queue from all LogRecords before removing the thread context
 
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
       return !thread_context->is_valid() && thread_context->event_spsc_queue().empty() &&
         thread_context->raw_spsc_queue().empty();
 #else
@@ -193,7 +193,7 @@ void ThreadContextCollection::_find_and_remove_invalidated_thread_contexts()
     // If the thread context is invalid it means the thread that created it has now died.
     // We also want to empty the queue from all LogRecords before removing the thread context
 
-#if defined(QUILL_DUAL_QUEUE_MODE)
+#if !defined(QUILL_DISABLE_DUAL_QUEUE_MODE)
         return !thread_context->is_valid() && thread_context->event_spsc_queue().empty() &&
           thread_context->raw_spsc_queue().empty();
 #else


### PR DESCRIPTION
Fixes #131: All options in TweakMe.h should be disabled by default. Otherwise options can not be enabled from the command line or cmake. This PR replaces QUILL_DUAL_QUEUE_MODE with QUILL_DISABLE_DUAL_QUEUE_MODE, which is disabled by default.