### PR TITLE
Fix initializations for C++17

### DIFF
--- a/quill/include/quill/detail/LogManager.h
+++ b/quill/include/quill/detail/LogManager.h
@@ -195,7 +195,7 @@ private:
   ThreadContextCollection _thread_context_collection{_config};
   LoggerCollection _logger_collection{_thread_context_collection, _handler_collection};
   BackendWorker _backend_worker{_config, _thread_context_collection, _handler_collection};
-  std::string _process_id{fmt::format_int(get_process_id()).str()};
+  std::string _process_id = fmt::format_int(get_process_id()).str();
 };
 } // namespace detail
 } // namespace quill

--- a/quill/include/quill/detail/ThreadContext.h
+++ b/quill/include/quill/detail/ThreadContext.h
@@ -151,8 +151,8 @@ private:
 #endif
 
   EventSPSCQueueT _event_spsc_queue; /** queue for this thread, events are pushed here */
-  std::string _thread_id{fmt::format_int(get_thread_id()).str()}; /**< cache this thread pid */
-  std::string _thread_name{get_thread_name()};                    /**< cache this thread name */
+  std::string _thread_id = fmt::format_int(get_thread_id()).str(); /**< cache this thread pid */
+  std::string _thread_name = get_thread_name();                    /**< cache this thread name */
   std::atomic<bool> _valid{true}; /**< is this context valid, set by the caller, read by the backend worker thread */
 
 #if defined(QUILL_USE_BOUNDED_QUEUE)

--- a/quill/include/quill/handlers/Handler.h
+++ b/quill/include/quill/handlers/Handler.h
@@ -121,7 +121,7 @@ public:
 private:
   /**< Owned formatter for this handler, we have to use a pointer here since the PatterFormatter
    * must not be moved or copied. We create the default pattern formatter always on init */
-  std::unique_ptr<PatternFormatter> _formatter{std::make_unique<PatternFormatter>()};
+  std::unique_ptr<PatternFormatter> _formatter = std::make_unique<PatternFormatter>();
 
   /** Local Filters for this handler **/
   std::vector<FilterBase*> _local_filters;


### PR DESCRIPTION
Some initializations using {} did not work when compiled with C++17