### PR TITLE
Use QUILL-prefixed logging macros in quill

### DIFF
--- a/quill/src/detail/SignalHandler.cpp
+++ b/quill/src/detail/SignalHandler.cpp
@@ -231,7 +231,7 @@ void on_signal(int32_t signal_number)
   else
   {
     // This means signal handler is running a caller thread, we can log from the default logger
-    LOG_INFO(quill::get_logger(), "Received signal: {}", ::strsignal(signal_number));
+    QUILL_LOG_INFO(quill::get_logger(), "Received signal: {}", ::strsignal(signal_number));
 
     if (signal_number == SIGINT || signal_number == SIGTERM)
     {
@@ -241,8 +241,8 @@ void on_signal(int32_t signal_number)
     }
     else
     {
-      LOG_CRITICAL(quill::get_logger(), "Terminated unexpectedly because of signal: {}",
-                   ::strsignal(signal_number));
+      QUILL_LOG_CRITICAL(quill::get_logger(), "Terminated unexpectedly because of signal: {}",
+                         ::strsignal(signal_number));
 
       quill::flush();
 


### PR DESCRIPTION
If the code is compiled with QUILL_DISABLE_NON_PREFIXED_MACROS, quill
fails to compile because it's using the non-prefixed macros in its own
code.

This commit changes the code to use the prefixed macros.