### PR TITLE
Fix compile warning in ThreadContext.h

### DIFF
--- a/quill/include/quill/detail/ThreadContext.h
+++ b/quill/include/quill/detail/ThreadContext.h
@@ -157,7 +157,12 @@ private:
 
 #if defined(QUILL_USE_BOUNDED_QUEUE)
   alignas(CACHELINE_SIZE) std::atomic<size_t> _dropped_message_counter{0};
+#ifdef __clang__
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-private-field"
   char _pad0[detail::CACHELINE_SIZE - sizeof(std::atomic<size_t>)] = "\0";
+  #pragma GCC diagnostic pop
+#endif
 #endif
 };
 } // namespace detail

--- a/quill/include/quill/detail/ThreadContext.h
+++ b/quill/include/quill/detail/ThreadContext.h
@@ -160,7 +160,9 @@ private:
 #ifdef __clang__
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wunused-private-field"
+#endif
   char _pad0[detail::CACHELINE_SIZE - sizeof(std::atomic<size_t>)] = "\0";
+#ifdef __clang__
   #pragma GCC diagnostic pop
 #endif
 #endif


### PR DESCRIPTION
The _pad0 field of ThreadContext is unused and causes a compiler warning
to be emitted with clang.

This commit suppresses the warning for clang.