### PR TITLE
Fix msvc compiler warning C5038 in MacroMetadata

### DIFF
--- a/quill/include/quill/MacroMetadata.h
+++ b/quill/include/quill/MacroMetadata.h
@@ -50,9 +50,9 @@ public:
       _lineno(lineno),
       _level(level),
       _event(event),
+      _is_structured_log_template(is_structured_log_template),
       _has_wide_char{true},
-      _wmessage_format(message_format),
-      _is_structured_log_template(is_structured_log_template)
+      _wmessage_format(message_format)
   {
   }
 #endif


### PR DESCRIPTION
Initialization order was incorrect on windows. The code does not compile if you have "treat warnings as errors" set.