### PR TITLE
Fix forward slashes not working on Windows

### DIFF
--- a/quill/include/quill/MacroMetadata.h
+++ b/quill/include/quill/MacroMetadata.h
@@ -135,7 +135,8 @@ private:
     char const* file = path;
     while (*path)
     {
-      if (*path++ == fs::path::preferred_separator)
+      char cur = *path++;
+      if (cur == '/' || cur == fs::path::preferred_separator)
       {
         file = path;
       }


### PR DESCRIPTION
MinGW generates paths with forward slashes in `__FILE__`. 
However, `fs::path::preferred_separator` is set to `\\` on Windows.

This is a fix to allow both separators to work.

This is ok as `/` is the ["portable separator"](https://en.cppreference.com/w/cpp/filesystem/path):
![image](https://user-images.githubusercontent.com/76668284/208194387-9aee760d-8674-4681-bc8f-ddd2711cde23.png)
