### PR TITLE
Remove trailing spaces in log levels strings

### DIFF
--- a/quill/include/quill/MacroMetadata.h
+++ b/quill/include/quill/MacroMetadata.h
@@ -162,8 +162,8 @@ private:
   QUILL_NODISCARD_ALWAYS_INLINE_HOT static std::string_view _log_level_to_string(LogLevel log_level)
   {
     static constexpr std::array<std::string_view, 10> log_levels_strings = {
-      {"TRACE_L3 ", "TRACE_L2 ", "TRACE_L1 ", "DEBUG    ", "INFO     ", "WARNING  ", "ERROR    ",
-       "CRITICAL ", "BACKTRACE", "NONE"}};
+      {"TRACE_L3", "TRACE_L2", "TRACE_L1", "DEBUG", "INFO", "WARNING", "ERROR",
+       "CRITICAL", "BACKTRACE", "NONE"}};
 
     using log_lvl_t = std::underlying_type<LogLevel>::type;
     return log_levels_strings[static_cast<log_lvl_t>(log_level)];

--- a/quill/test/MacroMetadataTest.cpp
+++ b/quill/test/MacroMetadataTest.cpp
@@ -34,7 +34,7 @@ TEST_CASE("construct")
     REQUIRE_EQ(log_line_info.level(), quill::LogLevel::Info);
     REQUIRE_STREQ(log_line_info.lineno().data(), "25");
     REQUIRE_STREQ(log_line_info.filename().data(), "MacroMetadataTest.cpp");
-    REQUIRE_STREQ(log_line_info.level_as_str().data(), "INFO     ");
+    REQUIRE_STREQ(log_line_info.level_as_str().data(), "INFO");
   }
 }
 


### PR DESCRIPTION
I'd like to format my messages with the following pattern : `"%(ascii_time) [%(logger_name)] [%(level_name)]: %(message)"`
But since the log levels strings contains trailing spaces, I get the following output :
```
01/28/23 12:37:06.275 [Output] [TRACE_L3 ]: 41
01/28/23 12:37:06.275 [Output] [TRACE_L2 ]: 18467
01/28/23 12:37:06.275 [Output] [TRACE_L1 ]: 6334
01/28/23 12:37:06.275 [Output] [DEBUG    ]: 26500
01/28/23 12:37:06.275 [Output] [INFO     ]: 19169
01/28/23 12:37:06.275 [Output] [WARNING  ]: 15724
01/28/23 12:37:06.275 [Output] [ERROR    ]: 11478
01/28/23 12:37:06.275 [Output] [CRITICAL ]: 29358
```
I understand those trailing spaces are here for aligning, but since the pattern string is converted to a fmt format string, I think it is better to remove the spaces from the log levels strings and use the following syntax instead : `%(level_name:<10)`