### PR TITLE
Fix memory leak from 'Support 'Windows 10 LTSB 2016, 1607 and Server 2016'

### DIFF
--- a/quill/src/detail/misc/Os.cpp
+++ b/quill/src/detail/misc/Os.cpp
@@ -146,6 +146,7 @@ ReturnT callRunTimeDynamicLinkedFunction(const std::string& dll_name,
 
   if (QUILL_UNLIKELY(callable == NULL))
   {
+    FreeLibrary(hinstLibrary);
     std::ostringstream error_msg;
     error_msg << "Failed to call "
               << "\"" << function_name << "\" in "


### PR DESCRIPTION
My previous pull request didn't free libraries in case of an error in 'GetProcAddress'.
This should fix it.