### PR TITLE
Fix compile warning on Apple M1

### DIFF
--- a/quill/include/quill/detail/misc/Rdtsc.h
+++ b/quill/include/quill/detail/misc/Rdtsc.h
@@ -31,7 +31,7 @@ QUILL_NODISCARD_ALWAYS_INLINE_HOT uint64_t rdtsc() noexcept
   // read at CNTFRQ special register.  We assume the OS has set up the virtual timer properly.
   int64_t virtual_timer_value;
   __asm__ volatile("mrs %0, cntvct_el0" : "=r"(virtual_timer_value));
-  return virtual_timer_value;
+  return static_cast<uint64_t>(virtual_timer_value);
 }
 #elif defined(__ARM_ARCH)
 QUILL_NODISCARD_ALWAYS_INLINE_HOT uint64_t rdtsc() noexcept


### PR DESCRIPTION
```
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/src/detail/backend/BackendWorker.cpp:1:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/backend/BackendWorker.h:13:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/LoggerCollection.h:9:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/Logger.h:18:
/Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/misc/Rdtsc.h:34:10: warning: implicit conversion changes signedness: 'int64_t' (aka 'long long') to 'uint64_t' (aka 'unsigned long long') [-Wsign-conversion]
  return virtual_timer_value;
  ~~~~~~ ^~~~~~~~~~~~~~~~~~~
1 warning generated.
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/src/detail/misc/RdtscClock.cpp:3:
/Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/misc/Rdtsc.h:34:10: warning: implicit conversion changes signedness: 'int64_t' (aka 'long long') to 'uint64_t' (aka 'unsigned long long') [-Wsign-conversion]
  return virtual_timer_value;
  ~~~~~~ ^~~~~~~~~~~~~~~~~~~
1 warning generated.
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/src/detail/LoggerCollection.cpp:1:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/LoggerCollection.h:9:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/Logger.h:18:
/Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/misc/Rdtsc.h:34:10: warning: implicit conversion changes signedness: 'int64_t' (aka 'long long') to 'uint64_t' (aka 'unsigned long long') [-Wsign-conversion]
  return virtual_timer_value;
  ~~~~~~ ^~~~~~~~~~~~~~~~~~~
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/src/detail/SignalHandler.cpp:8:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/Quill.h:12:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/LogMacros.h:10:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/Logger.h:18:
/Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/misc/Rdtsc.h:34:10: warning: implicit conversion changes signedness: 'int64_t' (aka 'long long') to 'uint64_t' (aka 'unsigned long long') [-Wsign-conversion]
  return virtual_timer_value;
  ~~~~~~ ^~~~~~~~~~~~~~~~~~~
1 warning generated.
1 warning generated.
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/src/Quill.cpp:1:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/Quill.h:12:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/LogMacros.h:10:
In file included from /Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/Logger.h:18:
/Users/jenkins/w/prod/BuildSingleReference@2/.conan/data/quill/2.9.0/_/_/build/182ec311e04295bce36a12820ce7004d2a380991/src/quill/include/quill/detail/misc/Rdtsc.h:34:10: warning: implicit conversion changes signedness: 'int64_t' (aka 'long long') to 'uint64_t' (aka 'unsigned long long') [-Wsign-conversion]
  return virtual_timer_value;
  ~~~~~~ ^~~~~~~~~~~~~~~~~~~
1 warning generated.
```

https://c3i.jfrog.io/c3i/misc/logs/pr/17550/1-macos-m1-clang/quill/2.9.0//182ec311e04295bce36a12820ce7004d2a380991-build.txt