### PR TITLE
pass Config by const reference to quill::configure()

### DIFF
--- a/quill/include/quill/Quill.h
+++ b/quill/include/quill/Quill.h
@@ -58,7 +58,7 @@ QUILL_ATTRIBUTE_COLD inline void preallocate()
  * @param config configuration
  * @note Has to be called before quill::start()
  */
-QUILL_ATTRIBUTE_COLD void configure(Config& config);
+QUILL_ATTRIBUTE_COLD void configure(Config const& config);
 
 /**
  * Starts the backend thread to write the logs to the handlers.

--- a/quill/src/Quill.cpp
+++ b/quill/src/Quill.cpp
@@ -21,7 +21,7 @@ namespace quill
 Logger* _g_root_logger = nullptr;
 
 /***/
-QUILL_ATTRIBUTE_COLD void configure(Config& config)
+QUILL_ATTRIBUTE_COLD void configure(Config const& config)
 {
   if (detail::LogManagerSingleton::instance().log_manager().backend_worker_is_running())
   {


### PR DESCRIPTION
A minor change, but seems very reasonable and allows `quill::configure(quill::Config{});`
