### PR TITLE
fix build failure of Intel Compiler Classic

### DIFF
--- a/quill/include/quill/detail/misc/Rdtsc.h
+++ b/quill/include/quill/detail/misc/Rdtsc.h
@@ -15,7 +15,7 @@
   // assume x86-64 ..
   #if defined(_WIN32)
     #include <intrin.h>
-  #elif (defined(__GNUC__) && __GNUC__ > 10) || (defined(__clang_major__) && __clang_major__ > 11)
+  #elif ((defined(__GNUC__) && __GNUC__ > 10) && !defined(__INTEL_COMPILER)) || (defined(__clang_major__) && __clang_major__ > 11)
     #include <x86gprintrin.h>
   #else
     // older compiler versions do not have <x86gprintrin.h>


### PR DESCRIPTION
Intel Compiler Classic itself doesn't have x86gprintrin.h and it seems incompatible with GCC's x86gprintrin.h

So the following code in quill/detail/misc/Rdtsc.h (line 18) will cause a build error.
```
#if defined(_WIN32)
  #include <intrin.h>
#elif (defined(__GNUC__) && __GNUC__ > 10) || (defined(__clang_major__) && __clang_major__ > 11)
  #include <x86gprintrin.h>
#else
  // older compiler versions do not have <x86gprintrin.h>
  #include <x86intrin.h>
#endif
```
This problem does not occur with the current Intel Compiler which is not Classic.
I hope you will take this into consideration because there are users like me.

Reproduce snipet by godbolt is here.
https://godbolt.org/z/Yx7vqsvEb
