### PR TITLE
added accessor method for Logger name

### DIFF
--- a/quill/include/quill/Logger.h
+++ b/quill/include/quill/Logger.h
@@ -371,6 +371,11 @@ private:
     return _is_invalidated.load(std::memory_order_acquire);
   }
 
+  /**
+   * @return The name of the logger
+   */
+  QUILL_NODISCARD std::string const& name() const noexcept { return _logger_details.name(); }
+
 private:
   detail::LoggerDetails _logger_details;
   TimestampClock* _custom_timestamp_clock{nullptr}; /* A non owned pointer to a custom timestamp clock, valid only when provided */


### PR DESCRIPTION
This is pretty minor but it would be useful for me. My use case is that I've implemented log level inheritance as a function of logger names, like log4cxx and (I think) log4j have. E.g., if you set the log level for logger "foo", then all loggers named "foo.xyz" for any xyz will automatically use the same log level as logger "foo".

If I had to, I could keep track of the logger names myself, via e.g. map<quill::Logger*, std::string> but since the Logger already has its name this seemed reasonable and obviously much more ergonomic for my case.

I considered adding accessors for some of the other things in LoggerDetails, but decided against it since I don't currently have any need for them.