### PR TITLE
fix lib and include paths

### DIFF
--- a/quill/cmake/quill.pc.in
+++ b/quill/cmake/quill.pc.in
@@ -1,8 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: quill
 Description: Low Latency C++ Logging Library


### PR DESCRIPTION
while trying to add this library to nixpkgs, I got this error:
```
Broken paths found in a .pc file! /nix/store/dl9q6b8qiglsd29fi9dg9y0byqzgmjmq-quillcpp-3.3.1/pkgconfig/quill.pc
The following lines have issues (specifically '//' in paths).
4:libdir=${exec_prefix}//nix/store/dl9q6b8qiglsd29fi9dg9y0byqzgmjmq-quillcpp-3.3.1/lib
5:includedir=${prefix}//nix/store/dl9q6b8qiglsd29fi9dg9y0byqzgmjmq-quillcpp-3.3.1/include
It is very likely that paths are being joined improperly.
ex: "${prefix}/@CMAKE_INSTALL_LIBDIR@" should be "@CMAKE_INSTALL_FULL_LIBDIR@"
Please see https://github.com/NixOS/nixpkgs/issues/144170 for more details.
```
builds fine after this commit, checked the file and the paths are correct on nix so this shouldn't break anything