### PR TITLE
better char array support

### DIFF
--- a/examples/example_trivial.cpp
+++ b/examples/example_trivial.cpp
@@ -42,6 +42,19 @@ int main()
     std::array<uint32_t, 4> arr = {1, 2, 3, 4};
     LOG_INFO(logger, "This is a log info example {}", arr);
 
+    union
+    {
+      char no_0[2];
+      char mid_0[6]{'1', '2', '3', '4', '\0', 6};
+    } char_arrays;
+
+    // only output "12" even if there's no '\0' at the end
+    LOG_INFO(logger, R"(This is a log info example for char array without '\0': {})", char_arrays.no_0);
+
+    // output "1234" until the '\0'
+    LOG_INFO(logger, R"(This is a log info example for char array with '\0' in middle: {})",
+             char_arrays.mid_0);
+
     // Using a dynamic runtime log level
     std::array<quill::LogLevel, 4> const runtime_log_levels = {
       quill::LogLevel::Debug, quill::LogLevel::Info, quill::LogLevel::Warning, quill::LogLevel::Error};

--- a/quill/include/quill/detail/misc/TypeTraitsCopyable.h
+++ b/quill/include/quill/detail/misc/TypeTraitsCopyable.h
@@ -60,6 +60,9 @@ struct remove_cvref
 template< class T >
 using remove_cvref_t = typename remove_cvref<T>::type;
 
+template <typename Arg>
+constexpr size_t array_size_v = std::extent<remove_cvref_t<Arg>>::value;
+
 /**
  * fmtquill::streamed detection
  */

--- a/quill/test/TypeTraitsCopyableTest.cpp
+++ b/quill/test/TypeTraitsCopyableTest.cpp
@@ -199,4 +199,13 @@ TEST_CASE("are_copyable")
   static_assert(!are_copyable_v<int, Enum, std::string, NonTrivial>, "_");
 }
 
+TEST_CASE("array_size_v")
+{
+  char a[3];
+  static_assert(array_size_v<decltype(a)> == 3, "_");
+
+  using B = char(&)[1];
+  static_assert(array_size_v<B> == 1, "_");
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
quill treats c array as c string and use `strlen()` to get the size of the c array buffer, which is not safe if the c array contain no `\0` at all.

this patch uses `strnlen()` and array size to fix this issue #351