### PR TITLE
Account for absolute CMAKE_INSTALL_<dir>

### DIFF
--- a/quill/cmake/quill.pc.in
+++ b/quill/cmake/quill.pc.in
@@ -1,8 +1,8 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
 
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: quill
 Description: Low Latency C++ Logging Library


### PR DESCRIPTION
CMake recomends to use CMAKE_INSTALL_FULL_\<dir> to get absolute install paths, in case CMAKE_INSTALL_\<dir> is already absolute.

https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html