### PR TITLE
Add missing cmake invocation install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -27,6 +27,7 @@ Building and Installing Quill as Static Library
    git clone https://github.com/odygrd/quill.git
    mkdir cmake_build
    cd cmake_build
+   cmake ..
    make install
 
 Note: To install in custom directory invoke cmake with ``-DCMAKE_INSTALL_PREFIX=/quill/install-dir/``


### PR DESCRIPTION
The "Building and Installing Quill"  step-by-step CLI example was missing the `cmake ..` invocation to create the Makefile for the next make step.