### PR TITLE
made Logger::name() public, added test case

### DIFF
--- a/quill/include/quill/Logger.h
+++ b/quill/include/quill/Logger.h
@@ -320,6 +320,11 @@ public:
     this->template log<decltype(anonymous_log_message_info)>(LogLevel::None, QUILL_FMT_STRING(""));
   }
 
+  /**
+   * @return The name of the logger
+   */
+  QUILL_NODISCARD std::string const& name() const noexcept { return _logger_details.name(); }
+
 private:
   friend class detail::LoggerCollection;
   friend class detail::LogManager;
@@ -370,11 +375,6 @@ private:
   {
     return _is_invalidated.load(std::memory_order_acquire);
   }
-
-  /**
-   * @return The name of the logger
-   */
-  QUILL_NODISCARD std::string const& name() const noexcept { return _logger_details.name(); }
 
 private:
   detail::LoggerDetails _logger_details;

--- a/quill/test/LoggerTest.cpp
+++ b/quill/test/LoggerTest.cpp
@@ -85,4 +85,17 @@ TEST_CASE("logger_should_log")
   REQUIRE_UNARY_FALSE(logger_collection.get_logger("logger_1")->should_log<LogLevel::Critical>());
 }
 
+/***/
+TEST_CASE("logger_name")
+{
+  Config cfg;
+  ThreadContextCollection tc{cfg};
+  HandlerCollection hc;
+
+  LoggerCollection logger_collection{cfg, tc, hc};
+
+  Logger* logger_1 = logger_collection.create_logger("logger_1", TimestampClockType::Tsc, nullptr);
+  REQUIRE_EQ(logger_1->name(), "logger_1");
+}
+
 TEST_SUITE_END();


### PR DESCRIPTION
Thanks for merging the previous PR to add Logger::name(). It looks like the method was made private during the merge, probably by accident (note that there are two separate 'private:' keywords in the declaration of Logger).

I made it public and added a case to LoggerTest.cpp to ensure that it's accessible.