### PR TITLE
fix windows clang-cl build error #399

### DIFF
--- a/quill/include/quill/detail/Serialize.h
+++ b/quill/include/quill/detail/Serialize.h
@@ -29,7 +29,7 @@ namespace detail
 {
 
 constexpr auto strnlen =
-#ifdef __STDC_LIB_EXT1__
+#if defined(__STDC_LIB_EXT1__) || defined(_MSC_VER)
   ::strnlen_s
 #else
   ::strnlen


### PR DESCRIPTION
This PR fixes Windows clang-cl build error: "constexpr variable 'strnlen' must be initialized by a constant expression. "

Unfortunately the strnlen() seems incompatible with constexpr in clang-cl compile.
But in the case of this case, MSVC/clang-cl can use the strnlen_s() function anyway.

This changes should only affects the Windows MSVC/clang-cl build.

descrived in #399 