### PR TITLE
CustomTags has a virtual destructor

### DIFF
--- a/quill/include/quill/detail/misc/Common.h
+++ b/quill/include/quill/detail/misc/Common.h
@@ -132,8 +132,8 @@ constexpr bool detect_structured_log_template(std::string_view fmt)
             continue;
           }
 
-            // we found '{' match, we can break
-            break;
+          // we found '{' match, we can break
+          break;
         }
 
         ++pos;
@@ -215,6 +215,7 @@ class CustomTags
 {
 public:
   constexpr CustomTags() = default;
+  virtual ~CustomTags() = default;
   virtual void format(std::string&) const = 0;
 };
 


### PR DESCRIPTION
When compiling with '-Wnon-virtual-dtor' the current code will lead to 

> Common.h:214:7: warning: 'quill::CustomTags' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]
> class CustomTags

This fixes that.