### PR TITLE
fix build failure of Intel Compiler Classic

### DIFF
--- a/quill/include/quill/detail/misc/Rdtsc.h
+++ b/quill/include/quill/detail/misc/Rdtsc.h
@@ -15,7 +15,7 @@
   // assume x86-64 ..
   #if defined(_WIN32)
     #include <intrin.h>
-  #elif __has_include(<x86gprintrin.h>)
+  #elif __has_include(<x86gprintrin.h>) && !defined(__INTEL_COMPILER)
     #include <x86gprintrin.h>
   #else
     #include <x86intrin.h>


### PR DESCRIPTION
Applied past 8df8f2e to current code. (#332)
Intel Compiler Classic itself doesn't have x86gprintrin.h and it seems incompatible with GCC's x86gprintrin.h

Unfortunately, __has_include(<x86gprintrin.h>) is set to true when build by Intel Compiler Classic.
This is because __has_include(<x86gprintrin.h>) finds the GCC include file.
It looks bad, but the only way to exclude it is to use "&& !defined(__INTEL_COMPILER)".

This is a problem only with Intel Compiler Classic, which is now deprecated.
The current Intel Compiler (icx) does not have the problem.

[Here ](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGe1wAyeAyYAHI%2BAEaYxCAAnKQADqgKhE4MHt6%2BekkpjgJBIeEsUTHxdpgOaUIETMQEGT5%2BXLaY9nkM1bUEBWGR0XG2NXUNWc0KQ93BvcX9sQCUtqhexMjsHCYaAILmAMx4VADUAPpHCEwKR8HI3lgQJjtuqgAcAGzACcTBBJ8MAHQI92wcw22zMewY1y8WAO90er3eP2%2BwX%2BgJBu1c%2BzRWy%2BBxYTGCEDmMIA7FYtgcKQdiJgCMsGAcNPcydtiQAREEcBa0TgAVl4fg4WlIqE4bms1gOCiWK0wMLBPFIBE0nIWAGsQGYefpOJJ%2BcrhZxeAoQBpFcqFnBYEg0CwEnRouRKDa7fQYnhkMgzBozFwuBpTTRaARosaIBF9RFgrUAJ6cBWR5jEaMAeQi2gqSu4vBtbEEyYYtFjgt4WAiXmAbjEtGNWdIWDxRnExbreGplQAbpga0LMKoKl5g3HeF9WvraHgIsQYx4sPqkSwh6RO8QIslMKzMA3gOOjOa%2BAZgAoAGp4TAAd2TCUYi/4ghEYnYUhkgkUKnUzd0zQMu9Mlms%2BgnY1IAWVAEnaGteFQZdPiwIDCRaNo0hcBh3E8Rp/BQnoihKbJklSAQRiaRI8PaLC%2BhiMZWgzKoJkIvRykqAROjqMiZgowYujosYJlYnCuAWKVllWCQuV5PVmxFDgDmeF4AFoXkkA53WQA4vR9X4/V%2BDQDggXBCBIOUdn43hMy0OYFgQTAmCwGJ4PVTVtQ4XVSAFIVJKNE0zWLC0YEQEAlgIBIB0dCBnXtYhQlYNZVAU3EFHbFT2y4WJfh2J5eEwfAiBgvRb2EURxCfPLXzUfVP1IM8pwSIdRI4PkXP1STkwHIKCAOVBDhk%2BTFOU1TvS4DSNC0nSPFtcLDOMryzLVDVJF%2BWIFsWpalpeRznNcyDDVsTzTM5UhLT8sLXRCo7%2BndVQ1J2H0%2BDoYNiFDcNmwTGNF2epNU3TBxFxzRgCHzQt9VLctK1oatF3rQxtzWIV8DbRxO27DK%2B2QAc1gVEduWbcdJ2nDBoZMz4F1rZdVyUDctx3UBvP3JhDxPc9L2vWs8vvQrpGKpRSo/DV9EhlBxUsACIjgkCwLSCDhWgvBYPgASqMYvwIFcLjSECKZsP6Zocnw9I0NGYjcjSXjNYQ6imNovWiIY9pmMmQpyPoi3Mitnj1Yd/jFiEx9avqjaDSkrrYvOvqwV%2BMwNJ0vTsomuYTPNGaHMx9bGq241TV28zHLMcS3K2jOFmXFJnEkIA%3D) is Reproduce snipet by godbolt.

