### PR TITLE
Fix missing cstdint include

### DIFF
--- a/quill/include/quill/LogLevel.h
+++ b/quill/include/quill/LogLevel.h
@@ -7,6 +7,7 @@
 
 #include "quill/detail/misc/Attributes.h" // for QUILL_NODISCARD
 #include <string>                         // for string
+#include <cstdint>
 
 namespace quill
 {

--- a/quill/include/quill/detail/misc/Common.h
+++ b/quill/include/quill/detail/misc/Common.h
@@ -8,6 +8,7 @@
 #include "quill/TweakMe.h"
 #include <string>
 #include <sstream>
+#include <cstdint>
 
 /**
  * Common type definitions etc


### PR DESCRIPTION
While trying to compile quill v1.7 I have encountered a compiler error.

Executing following series of commands
```
$ mkdir cmake_build
$ cd cmake_build/
$ cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release ..
```

Results in following error:
```
<path/to/quill>/quill/include/quill/detail/misc/Common.h:63:6: warning: elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword
   63 | enum class Timezone : uint8_t
      | ~~~~ ^~~~~
      |      -----
<path/to/quill>/quill/include/quill/detail/misc/Common.h:63:21: error: found ‘:’ in nested-name-specifier, expected ‘::’
   63 | enum class Timezone : uint8_t
      |                     ^
      |                     ::
```

Compiler version:
```
$ /usr/bin/c++  --version
c++ (GCC) 13.2.1 20240316 (Red Hat 13.2.1-7)
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

This error seems to be triggered by missing include of `cstdint`. Since enum class is using `uint8_t`  it would reasonable to expect that cstdint header has to be included directly. 