### PR TITLE
Macro metadata experiment

### DIFF
--- a/include/quill/CsvWriter.h
+++ b/include/quill/CsvWriter.h
@@ -63,7 +63,7 @@ public:
                                              }()),
       PatternFormatterOptions{"%(message)", "", Timezone::GmtTime});
 
-    _logger->template log_statement<false, false>(LogLevel::None, &_header_metadata, TCsvSchema::header);
+    _logger->template log_statement<false, decltype(_header_metadata)>(LogLevel::None, TCsvSchema::header);
   }
 
   /**
@@ -77,7 +77,7 @@ public:
     _logger = Frontend::create_or_get_logger(_logger_name_prefix + unique_name, std::move(sink),
                                              PatternFormatterOptions{"%(message)", "", Timezone::GmtTime});
 
-    _logger->template log_statement<false, false>(LogLevel::None, &_header_metadata, TCsvSchema::header);
+    _logger->template log_statement<false, decltype(_header_metadata)>(LogLevel::None, TCsvSchema::header);
   }
 
   /**
@@ -91,7 +91,7 @@ public:
     _logger = Frontend::create_or_get_logger(_logger_name_prefix + unique_name, sinks,
                                              PatternFormatterOptions{"%(message)", "", Timezone::GmtTime});
 
-    _logger->template log_statement<false, false>(LogLevel::None, &_header_metadata, TCsvSchema::header);
+    _logger->template log_statement<false, decltype(_header_metadata)>(LogLevel::None, TCsvSchema::header);
   }
 
   /**
@@ -111,7 +111,7 @@ public:
   template <typename... Args>
   void append_row(Args&&... fields)
   {
-    _logger->template log_statement<false, false>(LogLevel::None, &_line_metadata, fields...);
+    _logger->template log_statement<false, decltype(_line_metadata)>(LogLevel::None, fields...);
   }
 
   /**
@@ -121,11 +121,22 @@ public:
   void flush() { _logger->flush_log(); }
 
 private:
-  static constexpr MacroMetadata _header_metadata{
-    "", "", "{}", nullptr, LogLevel::Info, MacroMetadata::Event::Log};
+  struct
+  {
+    constexpr quill::MacroMetadata operator()() const noexcept
+    {
+      return quill::MacroMetadata{"", "", "{}", nullptr, LogLevel::Info, MacroMetadata::Event::Log};
+    }
+  } _header_metadata;
 
-  static constexpr MacroMetadata _line_metadata{
-    "", "", TCsvSchema::format, nullptr, LogLevel::Info, MacroMetadata::Event::Log};
+  struct
+  {
+    constexpr quill::MacroMetadata operator()() const noexcept
+    {
+      return quill::MacroMetadata{
+        "", "", TCsvSchema::format, nullptr, LogLevel::Info, MacroMetadata::Event::Log};
+    }
+  } _line_metadata;
 
   static inline std::string _logger_name_prefix{"__csv__"};
 

--- a/include/quill/LogMacros.h
+++ b/include/quill/LogMacros.h
@@ -311,8 +311,9 @@
   {                                                                                                \
     if (likelyhood(logger->template should_log_statement<log_level>()))                            \
     {                                                                                              \
-      QUILL_DEFINE_MACRO_METADATA(__FUNCTION__, fmt, tags, log_level);                             \
-      logger->template log_statement<QUILL_IMMEDIATE_FLUSH, false, decltype(anonymous_metadata)>(  \
+      static constexpr char const* function_name = __FUNCTION__;                                   \
+      QUILL_DEFINE_MACRO_METADATA(function_name, fmt, tags, log_level);                            \
+      logger->template log_statement<QUILL_IMMEDIATE_FLUSH, decltype(anonymous_metadata)>(         \
         quill::LogLevel::None, ##__VA_ARGS__);                                                     \
     }                                                                                              \
   } while (0)
@@ -340,8 +341,9 @@
   {                                                                                                \
     if (QUILL_LIKELY(logger->template should_log_statement<quill::LogLevel::Backtrace>()))         \
     {                                                                                              \
-      QUILL_DEFINE_MACRO_METADATA(__FUNCTION__, fmt, tags, quill::LogLevel::Backtrace);            \
-      logger->template log_statement<QUILL_IMMEDIATE_FLUSH, false, decltype(anonymous_metadata)>(  \
+      static constexpr char const* function_name = __FUNCTION__;                                   \
+      QUILL_DEFINE_MACRO_METADATA(function_name, fmt, tags, quill::LogLevel::Backtrace);           \
+      logger->template log_statement<QUILL_IMMEDIATE_FLUSH, decltype(anonymous_metadata)>(         \
         quill::LogLevel::None, ##__VA_ARGS__);                                                     \
     }                                                                                              \
   } while (0)
@@ -354,9 +356,10 @@
   do                                                                                                          \
   {                                                                                                           \
     if (logger->should_log_statement(log_level))                                                              \
-    {                                                                                                         \
-      QUILL_DEFINE_MACRO_METADATA(__FUNCTION__, fmt, tags, quill::LogLevel::Dynamic);              \
-      logger->template log_statement<QUILL_IMMEDIATE_FLUSH, true, decltype(anonymous_metadata)>(   \
+    {                                                                                              \
+      static constexpr char const* function_name = __FUNCTION__;                                   \
+      QUILL_DEFINE_MACRO_METADATA(function_name, fmt, tags, quill::LogLevel::Dynamic);             \
+      logger->template log_statement<QUILL_IMMEDIATE_FLUSH, decltype(anonymous_metadata)>(         \
         log_level, ##__VA_ARGS__);                                                                 \
     }                                                                                                         \
   } while (0)

--- a/include/quill/backend/BackendWorker.h
+++ b/include/quill/backend/BackendWorker.h
@@ -552,7 +552,7 @@ private:
     std::memcpy(&format_args_decoder, read_pos, sizeof(format_args_decoder));
     read_pos += sizeof(format_args_decoder);
 
-    *(transit_event->macro_metadata) = format_args_decoder(read_pos, _format_args_store);
+    transit_event->macro_metadata = format_args_decoder(read_pos, _format_args_store);
 
     if (transit_event->macro_metadata->event() != MacroMetadata::Event::Flush)
     {
@@ -928,11 +928,10 @@ private:
 
     for (auto& sink : transit_event.logger_base->sinks)
     {
-      if (sink->apply_all_filters(transit_event.macro_metadata.get(), transit_event.timestamp,
-                                  thread_id, thread_name, transit_event.logger_base->logger_name,
+      if (sink->apply_all_filters(transit_event.macro_metadata, transit_event.timestamp, thread_id, thread_name, transit_event.logger_base->logger_name,
                                   transit_event.log_level(), log_message, log_statement))
       {
-        sink->write_log(transit_event.macro_metadata.get(), transit_event.timestamp, thread_id,
+        sink->write_log(transit_event.macro_metadata, transit_event.timestamp, thread_id,
                         thread_name, _process_id, transit_event.logger_base->logger_name,
                         transit_event.log_level(), log_level_description, log_level_short_code,
                         transit_event.named_args.get(), log_message, log_statement);

--- a/include/quill/backend/SignalHandler.h
+++ b/include/quill/backend/SignalHandler.h
@@ -120,16 +120,22 @@ private:
   ~SignalHandlerContext() = default;
 };
 
-#define QUILL_SIGNAL_HANDLER_LOG(logger, log_level, fmt, ...)                                              \
-  do                                                                                                       \
-  {                                                                                                        \
-    if (logger->template should_log_statement<log_level>())                                                \
-    {                                                                                                      \
-      static constexpr quill::MacroMetadata macro_metadata{                                                \
-        "SignalHandler:~", "", fmt, nullptr, log_level, quill::MacroMetadata::Event::Log};                 \
-                                                                                                           \
-      logger->template log_statement<false, false>(quill::LogLevel::None, &macro_metadata, ##__VA_ARGS__); \
-    }                                                                                                      \
+#define QUILL_SIGNAL_HANDLER_LOG(logger, log_level, fmt, ...)                                                    \
+  do                                                                                                             \
+  {                                                                                                              \
+    if (logger->template should_log_statement<log_level>())                                                      \
+    {                                                                                                            \
+      struct                                                                                                     \
+      {                                                                                                          \
+        constexpr quill::MacroMetadata operator()() const noexcept                                               \
+        {                                                                                                        \
+          return quill::MacroMetadata{                                                                           \
+            "SignalHandler:~", "", fmt, nullptr, log_level, quill::MacroMetadata::Event::Log};                   \
+        }                                                                                                        \
+      } anonymous_metadata;                                                                                      \
+                                                                                                                 \
+      logger->template log_statement<false, decltype(anonymous_metadata)>(quill::LogLevel::None, ##__VA_ARGS__); \
+    }                                                                                                            \
   } while (0)
 
 /***/

--- a/include/quill/backend/TransitEvent.h
+++ b/include/quill/backend/TransitEvent.h
@@ -46,7 +46,7 @@ struct TransitEvent
   /***/
   TransitEvent(TransitEvent&& other) noexcept
     : timestamp(other.timestamp),
-      macro_metadata(other.macro_metadata),
+      macro_metadata(std::move(other.macro_metadata)),
       logger_base(other.logger_base),
       formatted_msg(std::move(other.formatted_msg)),
       named_args(std::move(other.named_args)),
@@ -61,7 +61,7 @@ struct TransitEvent
     if (this != &other)
     {
       timestamp = other.timestamp;
-      macro_metadata = other.macro_metadata;
+      macro_metadata = std::move(other.macro_metadata);
       logger_base = other.logger_base;
       formatted_msg = std::move(other.formatted_msg);
       named_args = std::move(other.named_args);
@@ -86,7 +86,7 @@ struct TransitEvent
   }
 
   uint64_t timestamp{0};
-  MacroMetadata const* macro_metadata{nullptr};
+  std::unique_ptr<MacroMetadata> macro_metadata{std::make_unique<MacroMetadata>()};
   detail::LoggerBase* logger_base{nullptr};
   std::unique_ptr<FormatBuffer> formatted_msg{std::make_unique<FormatBuffer>()}; /** buffer for message **/
   std::unique_ptr<std::vector<std::pair<std::string, std::string>>> named_args; /** A unique ptr to save space as named args feature is not always used */

--- a/include/quill/backend/TransitEvent.h
+++ b/include/quill/backend/TransitEvent.h
@@ -46,7 +46,7 @@ struct TransitEvent
   /***/
   TransitEvent(TransitEvent&& other) noexcept
     : timestamp(other.timestamp),
-      macro_metadata(std::move(other.macro_metadata)),
+      macro_metadata(other.macro_metadata),
       logger_base(other.logger_base),
       formatted_msg(std::move(other.formatted_msg)),
       named_args(std::move(other.named_args)),
@@ -61,7 +61,7 @@ struct TransitEvent
     if (this != &other)
     {
       timestamp = other.timestamp;
-      macro_metadata = std::move(other.macro_metadata);
+      macro_metadata = other.macro_metadata;
       logger_base = other.logger_base;
       formatted_msg = std::move(other.formatted_msg);
       named_args = std::move(other.named_args);
@@ -86,7 +86,7 @@ struct TransitEvent
   }
 
   uint64_t timestamp{0};
-  std::unique_ptr<MacroMetadata> macro_metadata{std::make_unique<MacroMetadata>()};
+  MacroMetadata const* macro_metadata{nullptr};
   detail::LoggerBase* logger_base{nullptr};
   std::unique_ptr<FormatBuffer> formatted_msg{std::make_unique<FormatBuffer>()}; /** buffer for message **/
   std::unique_ptr<std::vector<std::pair<std::string, std::string>>> named_args; /** A unique ptr to save space as named args feature is not always used */

--- a/include/quill/core/Codec.h
+++ b/include/quill/core/Codec.h
@@ -312,12 +312,12 @@ void decode_and_store_arg(std::byte*& buffer, QUILL_MAYBE_UNUSED DynamicFormatAr
 /**
  * Decode functions
  */
-using FormatArgsDecoder = MacroMetadata (*)(std::byte*& data, DynamicFormatArgStore& args_store);
+using FormatArgsDecoder = MacroMetadata const* (*)(std::byte*& data, DynamicFormatArgStore& args_store);
 
 template <typename TMacroMetadata, typename... Args>
-MacroMetadata decode_and_store_args(std::byte*& buffer, DynamicFormatArgStore& args_store)
+MacroMetadata const* decode_and_store_args(std::byte*& buffer, DynamicFormatArgStore& args_store)
 {
-  constexpr MacroMetadata macro_metadata = TMacroMetadata{}();
+  static constexpr MacroMetadata macro_metadata = TMacroMetadata{}();
 
   if constexpr (macro_metadata.event() != MacroMetadata::Event::Flush)
   {
@@ -326,7 +326,7 @@ MacroMetadata decode_and_store_args(std::byte*& buffer, DynamicFormatArgStore& a
     decode_and_store_arg<Args...>(buffer, &args_store);
   }
 
-  return macro_metadata;
+  return &macro_metadata;
 }
 } // namespace detail
 

--- a/include/quill/core/MacroMetadata.h
+++ b/include/quill/core/MacroMetadata.h
@@ -74,7 +74,7 @@ public:
     return _source_location + _file_name_pos;
   }
 
-  QUILL_NODISCARD LogLevel log_level() const noexcept { return _log_level; }
+  QUILL_NODISCARD constexpr LogLevel log_level() const noexcept { return _log_level; }
 
   QUILL_NODISCARD char const* tags() const noexcept { return _tags; }
 

--- a/include/quill/core/MacroMetadata.h
+++ b/include/quill/core/MacroMetadata.h
@@ -31,6 +31,8 @@ public:
     Flush
   };
 
+  MacroMetadata() = default;
+
   constexpr MacroMetadata(char const* source_location, char const* caller_function,
                           char const* message_format, char const* tags, LogLevel log_level, Event event) noexcept
     : _source_location(source_location),
@@ -78,7 +80,7 @@ public:
 
   QUILL_NODISCARD bool has_named_args() const noexcept { return _format_flags & NAMED_ARGS_FLAG; }
 
-  QUILL_NODISCARD Event event() const noexcept { return _event; }
+  QUILL_NODISCARD constexpr Event event() const noexcept { return _event; }
 
 private:
   /***/


### PR DESCRIPTION
This change increases binady size by aprox 0.5 MB

```
-rwxr-xr-x. 1 odygrd odygrd 3.7M Oct  8 19:25 BENCHMARK_quill_compile_time
-rwxr-xr-x. 1 odygrd odygrd 4.2M Oct  8 19:20 BENCHMARK_quill_compile_time_new
```

```
[compile_time]$ size BENCHMARK_quill_compile_time
   text    data     bss     dec     hex filename
3017591    1908    2032 3021531  2e1adb BENCHMARK_quill_compile_time

[compile_time]$ size BENCHMARK_quill_compile_time_new 
   text    data     bss     dec     hex filename
3112475    1908    2032 3116415  2f8d7f BENCHMARK_quill_compile_time_new
```

Compile times are also increased around 10%, seems it isn't worth it