### PR TITLE
fix cmake instructions

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -27,6 +27,7 @@ Building and Installing from Source
 .. code:: bash
 
    git clone https://github.com/odygrd/quill.git
+   cd quill
    mkdir cmake_build
    cd cmake_build
    cmake ..


### PR DESCRIPTION
update cmake instructions with missing 'cd quill' command