### PR TITLE
Improve variable conversion & comparison handling as well as CMake version compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,7 @@ target_include_directories(${TARGET_NAME}
 
 # Compiler options
 target_compile_options(${TARGET_NAME} INTERFACE
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-gnu-zero-variadic-macro-arguments -Wno-error=float-equal>)
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-gnu-zero-variadic-macro-arguments>)
 
 # Install
 if (QUILL_MASTER_PROJECT OR QUILL_ENABLE_INSTALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.10)
 project(quill)
 
 #-------------------------------------------------------------------------------------------------------
@@ -298,7 +298,7 @@ target_include_directories(${TARGET_NAME}
 
 # Compiler options
 target_compile_options(${TARGET_NAME} INTERFACE
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-gnu-zero-variadic-macro-arguments>)
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wno-gnu-zero-variadic-macro-arguments -Wno-error=float-equal>)
 
 # Install
 if (QUILL_MASTER_PROJECT OR QUILL_ENABLE_INSTALL)

--- a/include/quill/core/BoundedSPSCQueue.h
+++ b/include/quill/core/BoundedSPSCQueue.h
@@ -77,7 +77,7 @@ public:
                                                     integer_type reader_store_percent = 5)
     : _capacity(next_power_of_two(capacity)),
       _mask(_capacity - 1),
-      _bytes_per_batch(static_cast<integer_type>(_capacity * static_cast<double>(reader_store_percent) / 100.0)),
+      _bytes_per_batch(static_cast<integer_type>(static_cast<double>(_capacity * reader_store_percent) / 100.0)),
       _storage(static_cast<std::byte*>(_alloc_aligned(2ull * static_cast<uint64_t>(_capacity),
                                                       CACHE_LINE_ALIGNED, huges_pages_enabled))),
       _huge_pages_enabled(huges_pages_enabled)


### PR DESCRIPTION
Importing `quill` source code as part of a larger project can reveal points of improvement mainly pointed out by inherited compiler flags. Fixes include:


- Tolerate float comparison when using equality operator.   
```
# error
comparing floating point with == or != is unsafe [-Werror,-Wfloat-equal]
```
- Improve implicit conversion to avoid lose of precision (hopefully multiplication result falls in the original author's error tolerance intention).
```
# warning
  implicit conversion from 'const integer_type' (aka 'const unsigned long') to 'double' may lose precision [-Werror,-Wimplicit-int-float-conversion]
```
- Modern CMake versions (e.g. `3.31.5`) can reveal obsolete CMake policy incompatibility. Changing minimum version to `3.10` alleviates these warnings. Worth noting that current version `3.8` dates back to 2017. 
```
# warning message
CMake Deprecation Warning at extern/quill/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
<...>
```


