### PR TITLE
Fix FreeBSD build

### DIFF
--- a/include/quill/backend/BackendUtilities.h
+++ b/include/quill/backend/BackendUtilities.h
@@ -85,7 +85,8 @@ QUILL_ATTRIBUTE_COLD inline void set_cpu_affinity(uint16_t cpu_id)
   thread_port_t mach_thread = pthread_mach_thread_np(pthread_self());
 
   thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1);
-#elif defined(__NetBSD__)
+#else
+#if defined(__NetBSD__)
   cpuset_t *cpuset;
   cpuset = cpuset_create();
   auto const err = pthread_setaffinity_np(pthread_self(), cpuset_size(cpuset), cpuset);
@@ -110,6 +111,7 @@ QUILL_ATTRIBUTE_COLD inline void set_cpu_affinity(uint16_t cpu_id)
     QUILL_THROW(QuillError{std::string{"Failed to set cpu affinity - errno: " + std::to_string(errno) +
                                        " error: " + strerror(errno)}});
   }
+#endif
 }
 
 /***/

--- a/include/quill/backend/BackendWorker.h
+++ b/include/quill/backend/BackendWorker.h
@@ -1565,9 +1565,9 @@ private:
   std::atomic<uint32_t> _worker_thread_id{0};  /** cached backend worker thread id */
   std::atomic<bool> _is_worker_running{false}; /** The spawned backend thread status */
 
-  alignas(cache_line_aligned) std::atomic<RdtscClock*> _rdtsc_clock{
+  alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<RdtscClock*> _rdtsc_clock{
     nullptr}; /** rdtsc clock if enabled, can be accessed by any thread **/
-  alignas(cache_line_aligned) std::mutex _wake_up_mutex;
+  alignas(QUILL_CACHE_LINE_ALIGNED) std::mutex _wake_up_mutex;
   std::condition_variable _wake_up_cv;
   bool _wake_up_flag{false};
 };

--- a/include/quill/backend/BackendWorker.h
+++ b/include/quill/backend/BackendWorker.h
@@ -1565,9 +1565,9 @@ private:
   std::atomic<uint32_t> _worker_thread_id{0};  /** cached backend worker thread id */
   std::atomic<bool> _is_worker_running{false}; /** The spawned backend thread status */
 
-  alignas(CACHE_LINE_ALIGNED) std::atomic<RdtscClock*> _rdtsc_clock{
+  alignas(cache_line_aligned) std::atomic<RdtscClock*> _rdtsc_clock{
     nullptr}; /** rdtsc clock if enabled, can be accessed by any thread **/
-  alignas(CACHE_LINE_ALIGNED) std::mutex _wake_up_mutex;
+  alignas(cache_line_aligned) std::mutex _wake_up_mutex;
   std::condition_variable _wake_up_cv;
   bool _wake_up_flag{false};
 };

--- a/include/quill/backend/RdtscClock.h
+++ b/include/quill/backend/RdtscClock.h
@@ -208,7 +208,7 @@ private:
   int64_t _resync_interval_original{0}; /**< stores the initial interval value as as if we fail to resync we increase the timer */
   double _ns_per_tick{0};
 
-  alignas(CACHE_LINE_ALIGNED) mutable std::atomic<uint32_t> _version{0};
+  alignas(cache_line_aligned) mutable std::atomic<uint32_t> _version{0};
   mutable std::array<BaseTimeTsc, 2> _base{};
 };
 } // namespace detail

--- a/include/quill/backend/RdtscClock.h
+++ b/include/quill/backend/RdtscClock.h
@@ -208,7 +208,7 @@ private:
   int64_t _resync_interval_original{0}; /**< stores the initial interval value as as if we fail to resync we increase the timer */
   double _ns_per_tick{0};
 
-  alignas(cache_line_aligned) mutable std::atomic<uint32_t> _version{0};
+  alignas(QUILL_CACHE_LINE_ALIGNED) mutable std::atomic<uint32_t> _version{0};
   mutable std::array<BaseTimeTsc, 2> _base{};
 };
 } // namespace detail

--- a/include/quill/backend/ThreadUtilities.h
+++ b/include/quill/backend/ThreadUtilities.h
@@ -159,11 +159,15 @@ QUILL_NODISCARD QUILL_EXPORT QUILL_ATTRIBUTE_USED inline std::string get_thread_
 #else
   // Apple, linux
   char thread_name[16] = {'\0'};
+  #if defined(__FreeBSD__)
+  pthread_get_name_np(pthread_self(), &thread_name[0], 16);
+  #else
   auto res = pthread_getname_np(pthread_self(), &thread_name[0], 16);
   if (res != 0)
   {
     QUILL_THROW(QuillError{"Failed to get thread name. error: " + std::to_string(res)});
   }
+  #endif
   return std::string{&thread_name[0], strlen(&thread_name[0])};
 #endif
 }

--- a/include/quill/core/Attributes.h
+++ b/include/quill/core/Attributes.h
@@ -68,7 +68,6 @@
  */
 #ifndef QUILL_MAYBE_UNUSED
   #if QUILL_HAS_CPP_ATTRIBUTE(maybe_unused) && (defined(_HAS_CXX17) && _HAS_CXX17 == 1)
-    static_assert(false, "it's here")
     #define QUILL_MAYBE_UNUSED [[maybe_unused]]
   #elif QUILL_HAS_ATTRIBUTE(__unused__) || defined(__GNUC__)
     #define QUILL_MAYBE_UNUSED __attribute__((__unused__))

--- a/include/quill/core/Attributes.h
+++ b/include/quill/core/Attributes.h
@@ -68,6 +68,7 @@
  */
 #ifndef QUILL_MAYBE_UNUSED
   #if QUILL_HAS_CPP_ATTRIBUTE(maybe_unused) && (defined(_HAS_CXX17) && _HAS_CXX17 == 1)
+    static_assert(false, "it's here")
     #define QUILL_MAYBE_UNUSED [[maybe_unused]]
   #elif QUILL_HAS_ATTRIBUTE(__unused__) || defined(__GNUC__)
     #define QUILL_MAYBE_UNUSED __attribute__((__unused__))

--- a/include/quill/core/BoundedSPSCQueue.h
+++ b/include/quill/core/BoundedSPSCQueue.h
@@ -79,7 +79,7 @@ public:
       _mask(_capacity - 1),
       _bytes_per_batch(static_cast<integer_type>(static_cast<double>(_capacity * reader_store_percent) / 100.0)),
       _storage(static_cast<std::byte*>(_alloc_aligned(2ull * static_cast<uint64_t>(_capacity),
-                                                      CACHE_LINE_ALIGNED, huges_pages_enabled))),
+                                                      cache_line_aligned, huges_pages_enabled))),
       _huge_pages_enabled(huges_pages_enabled)
   {
     std::memset(_storage, 0, 2ull * static_cast<uint64_t>(_capacity));
@@ -89,7 +89,7 @@ public:
 
 #if defined(QUILL_X86ARCH)
     // remove log memory from cache
-    for (uint64_t i = 0; i < (2ull * static_cast<uint64_t>(_capacity)); i += CACHE_LINE_SIZE)
+    for (uint64_t i = 0; i < (2ull * static_cast<uint64_t>(_capacity)); i += cache_line_size)
     {
       _mm_clflush(_storage + i);
     }
@@ -104,7 +104,7 @@ public:
 
     for (uint64_t i = 0; i < cache_lines; ++i)
     {
-      _mm_prefetch(reinterpret_cast<char const*>(_storage + (CACHE_LINE_SIZE * i)), _MM_HINT_T0);
+      _mm_prefetch(reinterpret_cast<char const*>(_storage + (cache_line_size * i)), _MM_HINT_T0);
     }
 #endif
   }
@@ -145,7 +145,7 @@ public:
     _flush_cachelines(_last_flushed_writer_pos, _writer_pos);
 
     // prefetch a future cache line
-    _mm_prefetch(reinterpret_cast<char const*>(_storage + (_writer_pos & _mask) + (CACHE_LINE_SIZE * 10)),
+    _mm_prefetch(reinterpret_cast<char const*>(_storage + (_writer_pos & _mask) + (cache_line_size * 10)),
                  _MM_HINT_T0);
 #endif
   }
@@ -220,7 +220,7 @@ private:
     while (cur_diff > last_diff)
     {
       _mm_clflushopt(_storage + (last_diff & _mask));
-      last_diff += CACHE_LINE_SIZE;
+      last_diff += cache_line_size;
       last = last_diff;
     }
   }
@@ -322,7 +322,7 @@ private:
   }
 
 private:
-  static constexpr integer_type CACHELINE_MASK{CACHE_LINE_SIZE - 1};
+  static constexpr integer_type CACHELINE_MASK{cache_line_size - 1};
 
   integer_type const _capacity;
   integer_type const _mask;
@@ -330,13 +330,13 @@ private:
   std::byte* const _storage{nullptr};
   bool const _huge_pages_enabled;
 
-  alignas(CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_writer_pos{0};
-  alignas(CACHE_LINE_ALIGNED) integer_type _writer_pos{0};
+  alignas(cache_line_aligned) std::atomic<integer_type> _atomic_writer_pos{0};
+  alignas(cache_line_aligned) integer_type _writer_pos{0};
   integer_type _reader_pos_cache{0};
   integer_type _last_flushed_writer_pos{0};
 
-  alignas(CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_reader_pos{0};
-  alignas(CACHE_LINE_ALIGNED) integer_type _reader_pos{0};
+  alignas(cache_line_aligned) std::atomic<integer_type> _atomic_reader_pos{0};
+  alignas(cache_line_aligned) integer_type _reader_pos{0};
   mutable integer_type _writer_pos_cache{0};
   integer_type _last_flushed_reader_pos{0};
 };

--- a/include/quill/core/BoundedSPSCQueue.h
+++ b/include/quill/core/BoundedSPSCQueue.h
@@ -79,7 +79,7 @@ public:
       _mask(_capacity - 1),
       _bytes_per_batch(static_cast<integer_type>(static_cast<double>(_capacity * reader_store_percent) / 100.0)),
       _storage(static_cast<std::byte*>(_alloc_aligned(2ull * static_cast<uint64_t>(_capacity),
-                                                      cache_line_aligned, huges_pages_enabled))),
+                                                      QUILL_CACHE_LINE_ALIGNED, huges_pages_enabled))),
       _huge_pages_enabled(huges_pages_enabled)
   {
     std::memset(_storage, 0, 2ull * static_cast<uint64_t>(_capacity));
@@ -89,7 +89,7 @@ public:
 
 #if defined(QUILL_X86ARCH)
     // remove log memory from cache
-    for (uint64_t i = 0; i < (2ull * static_cast<uint64_t>(_capacity)); i += cache_line_size)
+    for (uint64_t i = 0; i < (2ull * static_cast<uint64_t>(_capacity)); i += QUILL_CACHE_LINE_SIZE)
     {
       _mm_clflush(_storage + i);
     }
@@ -104,7 +104,7 @@ public:
 
     for (uint64_t i = 0; i < cache_lines; ++i)
     {
-      _mm_prefetch(reinterpret_cast<char const*>(_storage + (cache_line_size * i)), _MM_HINT_T0);
+      _mm_prefetch(reinterpret_cast<char const*>(_storage + (QUILL_CACHE_LINE_SIZE * i)), _MM_HINT_T0);
     }
 #endif
   }
@@ -145,7 +145,7 @@ public:
     _flush_cachelines(_last_flushed_writer_pos, _writer_pos);
 
     // prefetch a future cache line
-    _mm_prefetch(reinterpret_cast<char const*>(_storage + (_writer_pos & _mask) + (cache_line_size * 10)),
+    _mm_prefetch(reinterpret_cast<char const*>(_storage + (_writer_pos & _mask) + (QUILL_CACHE_LINE_SIZE * 10)),
                  _MM_HINT_T0);
 #endif
   }
@@ -220,7 +220,7 @@ private:
     while (cur_diff > last_diff)
     {
       _mm_clflushopt(_storage + (last_diff & _mask));
-      last_diff += cache_line_size;
+      last_diff += QUILL_CACHE_LINE_SIZE;
       last = last_diff;
     }
   }
@@ -322,7 +322,7 @@ private:
   }
 
 private:
-  static constexpr integer_type CACHELINE_MASK{cache_line_size - 1};
+  static constexpr integer_type CACHELINE_MASK{QUILL_CACHE_LINE_SIZE - 1};
 
   integer_type const _capacity;
   integer_type const _mask;
@@ -330,13 +330,13 @@ private:
   std::byte* const _storage{nullptr};
   bool const _huge_pages_enabled;
 
-  alignas(cache_line_aligned) std::atomic<integer_type> _atomic_writer_pos{0};
-  alignas(cache_line_aligned) integer_type _writer_pos{0};
+  alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_writer_pos{0};
+  alignas(QUILL_CACHE_LINE_ALIGNED) integer_type _writer_pos{0};
   integer_type _reader_pos_cache{0};
   integer_type _last_flushed_writer_pos{0};
 
-  alignas(cache_line_aligned) std::atomic<integer_type> _atomic_reader_pos{0};
-  alignas(cache_line_aligned) integer_type _reader_pos{0};
+  alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_reader_pos{0};
+  alignas(QUILL_CACHE_LINE_ALIGNED) integer_type _reader_pos{0};
   mutable integer_type _writer_pos_cache{0};
   integer_type _last_flushed_reader_pos{0};
 };

--- a/include/quill/core/Common.h
+++ b/include/quill/core/Common.h
@@ -30,8 +30,8 @@ namespace detail
 /**
  * Cache line size
  */
-static constexpr size_t cache_line_size{64u};
-static constexpr size_t cache_line_aligned{2 * cache_line_size};
+static constexpr size_t QUILL_CACHE_LINE_SIZE{64u};
+static constexpr size_t QUILL_CACHE_LINE_ALIGNED{2 * QUILL_CACHE_LINE_SIZE};
 } // namespace detail
 
 /**

--- a/include/quill/core/Common.h
+++ b/include/quill/core/Common.h
@@ -30,8 +30,8 @@ namespace detail
 /**
  * Cache line size
  */
-static constexpr size_t CACHE_LINE_SIZE{64u};
-static constexpr size_t CACHE_LINE_ALIGNED{2 * CACHE_LINE_SIZE};
+static constexpr size_t cache_line_size{64u};
+static constexpr size_t cache_line_aligned{2 * cache_line_size};
 } // namespace detail
 
 /**

--- a/include/quill/core/InlinedVector.h
+++ b/include/quill/core/InlinedVector.h
@@ -169,7 +169,7 @@ private:
  * The capacity of 12 is chosen to fit within a full cache line for better performance.
  */
 using SizeCacheVector = InlinedVector<uint32_t, 12>;
-static_assert(sizeof(SizeCacheVector) <= CACHE_LINE_SIZE,
+static_assert(sizeof(SizeCacheVector) <= cache_line_size,
               "SizeCacheVector should not exceed a cache line");
 } // namespace detail
 

--- a/include/quill/core/InlinedVector.h
+++ b/include/quill/core/InlinedVector.h
@@ -169,7 +169,7 @@ private:
  * The capacity of 12 is chosen to fit within a full cache line for better performance.
  */
 using SizeCacheVector = InlinedVector<uint32_t, 12>;
-static_assert(sizeof(SizeCacheVector) <= cache_line_size,
+static_assert(sizeof(SizeCacheVector) <= QUILL_CACHE_LINE_SIZE,
               "SizeCacheVector should not exceed a cache line");
 } // namespace detail
 

--- a/include/quill/core/MacroMetadata.h
+++ b/include/quill/core/MacroMetadata.h
@@ -203,7 +203,7 @@ private:
   uint8_t _format_flags{0};
 };
 
-static_assert(sizeof(MacroMetadata) <= detail::cache_line_size,
+static_assert(sizeof(MacroMetadata) <= detail::QUILL_CACHE_LINE_SIZE,
               "Size of MacroMetadata exceeds the cache line size");
 
 QUILL_END_NAMESPACE

--- a/include/quill/core/MacroMetadata.h
+++ b/include/quill/core/MacroMetadata.h
@@ -203,7 +203,7 @@ private:
   uint8_t _format_flags{0};
 };
 
-static_assert(sizeof(MacroMetadata) <= detail::CACHE_LINE_SIZE,
+static_assert(sizeof(MacroMetadata) <= detail::cache_line_size,
               "Size of MacroMetadata exceeds the cache line size");
 
 QUILL_END_NAMESPACE

--- a/include/quill/core/ThreadContextManager.h
+++ b/include/quill/core/ThreadContextManager.h
@@ -214,7 +214,7 @@ private:
   std::shared_ptr<TransitEventBuffer> _transit_event_buffer; /**< backend thread buffer. this could be unique_ptr but it is shared_ptr because of the forward declaration */
   QueueType _queue_type;
   std::atomic<bool> _valid{true}; /**< is this context valid, set by the frontend, read by the backend thread */
-  alignas(cache_line_aligned) std::atomic<size_t> _failure_counter{0};
+  alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<size_t> _failure_counter{0};
 };
 
 class ThreadContextManager

--- a/include/quill/core/ThreadContextManager.h
+++ b/include/quill/core/ThreadContextManager.h
@@ -214,7 +214,7 @@ private:
   std::shared_ptr<TransitEventBuffer> _transit_event_buffer; /**< backend thread buffer. this could be unique_ptr but it is shared_ptr because of the forward declaration */
   QueueType _queue_type;
   std::atomic<bool> _valid{true}; /**< is this context valid, set by the frontend, read by the backend thread */
-  alignas(CACHE_LINE_ALIGNED) std::atomic<size_t> _failure_counter{0};
+  alignas(cache_line_aligned) std::atomic<size_t> _failure_counter{0};
 };
 
 class ThreadContextManager

--- a/include/quill/core/UnboundedSPSCQueue.h
+++ b/include/quill/core/UnboundedSPSCQueue.h
@@ -310,8 +310,8 @@ private:
 
 private:
   /** Modified by either the producer or consumer but never both */
-  alignas(CACHE_LINE_ALIGNED) Node* _producer{nullptr};
-  alignas(CACHE_LINE_ALIGNED) Node* _consumer{nullptr};
+  alignas(cache_line_aligned) Node* _producer{nullptr};
+  alignas(cache_line_aligned) Node* _consumer{nullptr};
 };
 
 } // namespace detail

--- a/include/quill/core/UnboundedSPSCQueue.h
+++ b/include/quill/core/UnboundedSPSCQueue.h
@@ -310,8 +310,8 @@ private:
 
 private:
   /** Modified by either the producer or consumer but never both */
-  alignas(cache_line_aligned) Node* _producer{nullptr};
-  alignas(cache_line_aligned) Node* _consumer{nullptr};
+  alignas(QUILL_CACHE_LINE_ALIGNED) Node* _producer{nullptr};
+  alignas(QUILL_CACHE_LINE_ALIGNED) Node* _consumer{nullptr};
 };
 
 } // namespace detail


### PR DESCRIPTION
Some issues I found while trying to build for freebsd.
There were not many of them but the funniest one was `CACHE_LINE_SIZE` which is defined in freebsd header so there is a conflict.
Wasn't sure if you insist for uppercase for constants, I saw some constants in lowercase so I opted for this solution.