### PR TITLE
Change the default open mode of FileSink to be 'a'

### DIFF
--- a/include/quill/sinks/FileSink.h
+++ b/include/quill/sinks/FileSink.h
@@ -197,7 +197,7 @@ public:
   }
 
 private:
-  std::string _open_mode{'w'};
+  std::string _open_mode{'a'};
   std::string _append_filename_format_pattern;
   size_t _write_buffer_size{64 * 1024}; // Default size 64k
   std::chrono::milliseconds _minimum_fsync_interval{0};


### PR DESCRIPTION
Change the default open mode of FileSink to be 'a' to make it match the comment.

The comment says the default open mode is 'a' but actually it is 'w'...

I think most people do not like the log file be overwritten to empty in every restart. Correct it be 'a' again.