### PR TITLE
Added a fix in create_or_get_logger function to check logger_ptr prior to use (#748)

### DIFF
--- a/include/quill/core/LoggerManager.h
+++ b/include/quill/core/LoggerManager.h
@@ -146,7 +146,7 @@ public:
       // the logger. This section is not performance-critical.
       logger_ptr = _find_logger(logger_name);
 
-      if (_env_log_level)
+      if (logger_ptr && _env_log_level)
       {
         logger_ptr->set_log_level(*_env_log_level);
       }


### PR DESCRIPTION
Added check to ensure logger_ptr is not null. logger_ptr is set to _find_logger and there is a possibility for this function to return nullptr.
```cpp 
return (search_it != std::end(_loggers) && search_it->get()->get_logger_name() == target)
      ? search_it->get()
      : nullptr;
```