### PR TITLE
Fix for failing i386 build #753

### DIFF
--- a/include/quill/StringRef.h
+++ b/include/quill/StringRef.h
@@ -35,7 +35,7 @@ public:
   explicit StringRef(std::string const& str) : _str_view(str) {};
   explicit StringRef(std::string_view str) : _str_view(str) {};
   explicit StringRef(char const* str)
-    : _str_view(str, detail::safe_strnlen(str, std::numeric_limits<uint32_t>::max())) {};
+    : _str_view(str, detail::safe_strnlen(str, quill::MAX_MEMCHR_EXAMINE_SIZE)) {};
   StringRef(char const* str, size_t size) : _str_view(str, size) {};
 
   QUILL_NODISCARD std::string_view const& get_string_view() const noexcept { return _str_view; }

--- a/include/quill/core/Codec.h
+++ b/include/quill/core/Codec.h
@@ -125,9 +125,9 @@ struct Codec
     {
       size_t constexpr N = std::extent_v<Arg>;
       size_t len = detail::safe_strnlen(arg, N) + 1u;
-      if (QUILL_UNLIKELY(len > std::numeric_limits<uint32_t>::max()))
+      if (QUILL_UNLIKELY(len > quill::MAX_MEMCHR_EXAMINE_SIZE))
       {
-        len = std::numeric_limits<uint32_t>::max();
+        len = quill::MAX_MEMCHR_EXAMINE_SIZE;
       }
       return conditional_arg_size_cache.push_back(static_cast<uint32_t>(len));
     }
@@ -135,11 +135,11 @@ struct Codec
     {
       // for c strings we do an additional check for nullptr
       // include one extra for the zero termination
-      size_t len = detail::safe_strnlen(arg, std::numeric_limits<uint32_t>::max()) + 1u;
+      size_t len = detail::safe_strnlen(arg, quill::MAX_MEMCHR_EXAMINE_SIZE) + 1u;
 
-      if (QUILL_UNLIKELY(len > std::numeric_limits<uint32_t>::max()))
+      if (QUILL_UNLIKELY(len > quill::MAX_MEMCHR_EXAMINE_SIZE))
       {
-        len = std::numeric_limits<uint32_t>::max();
+        len = quill::MAX_MEMCHR_EXAMINE_SIZE;
       }
 
       return conditional_arg_size_cache.push_back(static_cast<uint32_t>(len));
@@ -233,7 +233,7 @@ struct Codec
     {
       // c strings or char array
       auto arg = reinterpret_cast<char const*>(buffer);
-      buffer += detail::safe_strnlen(arg, std::numeric_limits<uint32_t>::max()) +
+      buffer += detail::safe_strnlen(arg, quill::MAX_MEMCHR_EXAMINE_SIZE) +
         1u; // for c_strings we add +1 to the length as we also want to copy the null terminated char
       return arg;
     }
@@ -271,7 +271,7 @@ struct Codec
       // we pass fmtquill::string_view since fmt/base.h includes a formatter for that type.
       // for std::string_view we would need fmt/format.h
       args_store->push_back(
-        fmtquill::string_view{arg, detail::safe_strnlen(arg, std::numeric_limits<uint32_t>::max())});
+        fmtquill::string_view{arg, detail::safe_strnlen(arg, quill::MAX_MEMCHR_EXAMINE_SIZE)});
     }
     else if constexpr (std::disjunction_v<detail::is_std_string<Arg>, std::is_same<Arg, std::string_view>>)
     {

--- a/include/quill/core/Common.h
+++ b/include/quill/core/Common.h
@@ -83,4 +83,11 @@ enum class HugePagesPolicy
   Try     // Try huge pages, but fall back to normal pages if unavailable
 };
 
+#if defined(__i386__) || defined(__arm__)
+// On i386, armel and armhf std::memchr "max number of bytes to examine" set to maximum size of unsigned int which does not work
+// current Debian package is using architecture any
+static constexpr int32_t MAX_MEMCHR_EXAMINE_SIZE = 2147483647;  // 2^31 - 1
+#else
+static constexpr uint32_t MAX_MEMCHR_EXAMINE_SIZE = 4294967295;  // 2^32 - 1
+#endif
 QUILL_END_NAMESPACE

--- a/test/unit_tests/UnboundedQueueTest.cpp
+++ b/test/unit_tests/UnboundedQueueTest.cpp
@@ -65,7 +65,7 @@ TEST_CASE("unbounded_queue_shrink")
 
 TEST_CASE("unbounded_queue_allocation_within_limit")
 {
-  UnboundedSPSCQueue buffer{1024, std::numeric_limits<uint64_t>::max()};
+  UnboundedSPSCQueue buffer{1024, std::numeric_limits<uint32_t>::max()};
 
   static constexpr size_t two_mb = 2u * 1024u * 1024u;
 


### PR DESCRIPTION
With CI/CD enabled on salsa i386 build failed. Problem was identified in a test and library files. For the test a conditional compilation flag was introduce to differential between 32bit and 64bit platforms. While in the library the problem was due to **std::memchr** "max number of bytes to examine" set to maximum size of unsigned int which does not work on i386 platform.