### PR TITLE
Add QUILL_DISABLE_FILE_INFO to disable `__FILE__` and `__LINE__` in LOG_* macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- [v9.0.3](#v903)
 - [v9.0.2](#v902)
 - [v9.0.1](#v901)
 - [v9.0.0](#v900)
@@ -86,6 +87,12 @@
 - [v1.2.0](#v120)
 - [v1.1.0](#v110)
 - [v1.0.0](#v100)
+
+## v9.0.3
+
+- Added the `QUILL_DISABLE_FILE_INFO` preprocessor flag and CMake option.  
+  This allows disabling `__FILE__` in `LOG_*` macros when `%(file_name)` or `%(line_number)` is not used in `PatternFormatter`,  
+  removing embedded strings from built binaries.
 
 ## v9.0.2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ option(QUILL_DISABLE_NON_PREFIXED_MACROS "Enable this option to disable non-pref
 
 option(QUILL_DISABLE_FUNCTION_NAME "Disable the use of __FUNCTION__ in `LOG_*` macros when the function name is not needed." OFF)
 
+option(QUILL_DISABLE_FILE_INFO "Disable the use of __FILE__ and __LINE__ in `LOG_*` macros when the file name and the line number are not needed." OFF)
+
 option(QUILL_BUILD_EXAMPLES "Enable this option to build and install the examples. Set this to ON to include example projects in the build process and have them installed after configuring with CMake." OFF)
 
 option(QUILL_BUILD_TESTS "Enable this option to build the test suite." OFF)
@@ -119,6 +121,7 @@ message(STATUS "QUILL_NO_THREAD_NAME_SUPPORT: " ${QUILL_NO_THREAD_NAME_SUPPORT})
 message(STATUS "QUILL_X86ARCH: " ${QUILL_X86ARCH})
 message(STATUS "QUILL_DISABLE_NON_PREFIXED_MACROS: " ${QUILL_DISABLE_NON_PREFIXED_MACROS})
 message(STATUS "QUILL_DISABLE_FUNCTION_NAME: " ${QUILL_DISABLE_FUNCTION_NAME})
+message(STATUS "QUILL_DISABLE_FILE_INFO: " ${QUILL_DISABLE_FILE_INFO})
 message(STATUS "QUILL_ENABLE_INSTALL: " ${QUILL_ENABLE_INSTALL})
 
 #---------------------------------------------------------------------------------------
@@ -283,6 +286,10 @@ endif ()
 
 if (QUILL_DISABLE_FUNCTION_NAME)
     target_compile_definitions(${TARGET_NAME} PUBLIC INTERFACE -DQUILL_DISABLE_FUNCTION_NAME)
+endif ()
+
+if (QUILL_DISABLE_FILE_INFO)
+    target_compile_definitions(${TARGET_NAME} PUBLIC INTERFACE -DQUILL_DISABLE_FILE_INFO)
 endif ()
 
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)

--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -43,6 +43,12 @@ Disables the use of ``__FUNCTION__`` in ``LOG_*`` macros. When ``%(caller_functi
 
 .. code:: cmake
 
+    add_compile_definitions(-DQUILL_DISABLE_FILE_INFO)
+
+Disables the use of ``__FILE__`` and ``__LINE__`` in ``LOG_*`` macros. When ``%(file_name)`` or ``%(line_number)`` is not used in ``PatternFormatter``, ``__FILE__`` and ``__LINE__`` can be disabled to remove embedded strings from built binaries.
+
+.. code:: cmake
+
     add_compile_definitions(-DQUILL_IMMEDIATE_FLUSH=1)
 
 Enables immediate flushing after each log statement by calling ``flush_log()``. This blocks execution until the backend processes the log statement, effectively simulating synchronous logging. This option is useful in debug builds, especially when stepping through a debugger.

--- a/include/quill/LogMacros.h
+++ b/include/quill/LogMacros.h
@@ -51,6 +51,14 @@
   #endif
 #endif
 
+#if !defined(QUILL_FILE_INFO)
+  #if defined(QUILL_DISABLE_FILE_INFO)
+    #define QUILL_FILE_INFO ""
+  #else
+    #define QUILL_FILE_INFO __FILE__ ":" QUILL_STRINGIFY(__LINE__)
+  #endif
+#endif
+
 /** -- LOGV_ helpers begin -- **/
 
 // Helper macro to expand __VA_ARGS__ correctly in MSVC
@@ -307,8 +315,7 @@
 #define QUILL_DEFINE_MACRO_METADATA(caller_function, fmt, tags, log_level)                         \
   static constexpr quill::MacroMetadata macro_metadata                                             \
   {                                                                                                \
-    __FILE__ ":" QUILL_STRINGIFY(__LINE__), caller_function, fmt, tags, log_level,                 \
-      quill::MacroMetadata::Event::Log                                                             \
+    QUILL_FILE_INFO, caller_function, fmt, tags, log_level, quill::MacroMetadata::Event::Log       \
   }
 
 #define QUILL_LOGGER_CALL(likelyhood, logger, tags, log_level, fmt, ...)                           \


### PR DESCRIPTION
When writing production codes,