### PR TITLE
Fix for i386 time_t within calculate initial rotation tp #669.

### DIFF
--- a/include/quill/sinks/RotatingSink.h
+++ b/include/quill/sinks/RotatingSink.h
@@ -694,7 +694,12 @@ private:
   /***/
   static uint64_t _calculate_initial_rotation_tp(uint64_t start_time_ns, RotatingFileSinkConfig const& config)
   {
+// time_t on i386 is 32 bits so casting out of range number results in zero
+#if (defined(__i386))
+    time_t const time_now = static_cast<time_t>(start_time_ns / 1000000000);
+#else
     time_t const time_now = static_cast<time_t>(start_time_ns) / 1000000000;
+#endif
     tm date;
 
     // here we do this because of `daily_rotation_time_str` that might have specified the time in UTC


### PR DESCRIPTION
Debian packaging 1 test failed due time_t size on i386.
Within _calculate_initial_rotation_tp function time_now value results in zero due to out of range value casting to time_t. 

Reference:
Job: https://debusine.debian.net/debian/developers/artifact/2153871/#L5754-files
Pipeline: https://debusine.debian.net/debian/developers/work-request/127768/