### PR TITLE
Fix armel atomic linking error #669.

### DIFF
--- a/cmake/QuillUtils.cmake
+++ b/cmake/QuillUtils.cmake
@@ -1,3 +1,5 @@
+include(CheckCXXSourceCompiles)
+
 # Get Quill version from include/quill/Version.h and store it as QUILL_VERSION
 function(quill_extract_version)
     file(READ "${CMAKE_CURRENT_LIST_DIR}/include/quill/Backend.h" file_contents)
@@ -86,3 +88,18 @@ function(set_common_compile_options target_name)
     endif ()
 endfunction()
 
+function(check_cxx_atomics_available variable)
+  set(SAVED_CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
+  set(CMAKE_REQUIRED_LIBRARIES "")
+
+  check_cxx_source_compiles("
+    #include <atomic>
+    #include <cstdint>
+    std::atomic<uint64_t> counter;
+    int main() {
+      uint64_t res = std::atomic_fetch_add(&counter, 1);
+      return (int)res;
+    }" ${variable})
+
+  set(CMAKE_REQUIRED_LIBRARIES "${SAVED_CMAKE_REQUIRED_LIBRARIES}")
+endfunction()

--- a/test/integration_tests/CMakeLists.txt
+++ b/test/integration_tests/CMakeLists.txt
@@ -28,8 +28,13 @@ function(quill_add_test TEST_NAME SOURCES)
             PRIVATE
             ..)
 
-    # Link dependencies with atomic lib for armel.
-    target_link_libraries(${TEST_NAME} quill atomic)
+    # Link dependencies
+    check_cxx_atomics_available(HAVE_CXX_ATOMIC)
+    if (HAVE_CXX_ATOMIC)
+        target_link_libraries(${TEST_NAME} quill)
+    else()
+        target_link_libraries(${TEST_NAME} quill atomic)
+    endif()
 
     if (QUILL_ENABLE_EXTENSIVE_TESTS)
         target_compile_definitions(${TEST_NAME} PRIVATE QUILL_ENABLE_EXTENSIVE_TESTS)

--- a/test/integration_tests/CMakeLists.txt
+++ b/test/integration_tests/CMakeLists.txt
@@ -28,8 +28,8 @@ function(quill_add_test TEST_NAME SOURCES)
             PRIVATE
             ..)
 
-    # Link dependencies
-    target_link_libraries(${TEST_NAME} quill)
+    # Link dependencies with atomic lib for armel.
+    target_link_libraries(${TEST_NAME} quill atomic)
 
     if (QUILL_ENABLE_EXTENSIVE_TESTS)
         target_compile_definitions(${TEST_NAME} PRIVATE QUILL_ENABLE_EXTENSIVE_TESTS)


### PR DESCRIPTION
This method is chosen for fixing armel atomic linking error for CMake  project due to order of libraries. Placing the library linking prior to file does not works as explained on https://github.com/scipy/scipy/issues/19982#issuecomment-1925322060