### PR TITLE
Fix: Resolve `operator||` ambiguity conflict with `boost::sml` on older GCC

### DIFF
--- a/include/quill/bundled/fmt/format.h
+++ b/include/quill/bundled/fmt/format.h
@@ -3176,7 +3176,7 @@ FMTQUILL_CONSTEXPR20 auto format_float(Float value, int precision,
   int exp = 0;
   bool use_dragon = true;
   unsigned dragon_flags = 0;
-  if (!is_fast_float<Float>() || is_constant_evaluated()) {
+  if (!is_fast_float<Float>::value || is_constant_evaluated()) {
     const auto inv_log2_10 = 0.3010299956639812;  // 1 / log2(10)
     using info = dragonbox::float_info<decltype(converted_value)>;
     const auto f = basic_fp<typename info::carrier_uint>(converted_value);


### PR DESCRIPTION
## Description
This PR fixes a compilation failure on Ubuntu 20.04 (GCC 9) and 22.04 (GCC 11) when `quill` is used in the same translation unit as `boost::sml`, when `using namespace boost::sml;` is present.

Fixes #877 

## Code Changes
In `include/quill/bundled/fmt/format.h`, I changed the instantiation of the `is_fast_float` trait to a direct static constant access.

## Explanation
By accessing `::value` directly, we resolve the expression to a primitive bool immediately. Primitive types are not subject to argument dependent lookup or user-defined operator overloads. This prevents `boost::sml` (or any other library with aggressive operator overloads) from intercepting the logic, ensuring the compiler uses the built-in boolean operator||.

## Note
I acknowledge that `using namespace boost::sml;` acts as a trigger for this issue by polluting the global namespace with greedy template operators. While this is actually an issue with how `boost::sml` handles its DSL, this small change in quill makes the library significantly more robust against such environmental conditions without any performance cost or functional change.
