### PR TITLE
Use soft rdtsc fallback on 32-bit PowerPC

### DIFF
--- a/include/quill/core/Rdtsc.h
+++ b/include/quill/core/Rdtsc.h
@@ -95,7 +95,7 @@ QUILL_NODISCARD QUILL_ATTRIBUTE_HOT inline uint64_t rdtsc() noexcept
   __asm__ volatile("stck %0" : "=Q"(tsc) : : "cc");
   return tsc;
 }
-#elif (defined(_M_ARM) || defined(_M_ARM64) || defined(__PPC64__))
+#elif (defined(_M_ARM) || defined(_M_ARM64) || defined(__PPC64__) || defined(__PPC__))
 QUILL_NODISCARD QUILL_ATTRIBUTE_HOT inline uint64_t rdtsc() noexcept
 {
   // soft failover


### PR DESCRIPTION
Quill's rdtsc helper already avoids __rdtsc() on ARM and PPC64, but 32-bit PowerPC was not included in that guard. On powerpc targets this falls through to the x86-specific intrinsic and fails with:

  error: '__rdtsc' was not declared in this scope

Treat common 32-bit PowerPC compiler define the same way as PPC64 and use the existing steady_clock-based fallback.