### PR TITLE
Reorganize #ifdef guards and private members in BoundedSPSCQueueImpl

### DIFF
--- a/include/quill/core/BoundedSPSCQueue.h
+++ b/include/quill/core/BoundedSPSCQueue.h
@@ -326,7 +326,11 @@ private:
   }
 
 private:
+#ifdef QUILL_X86ARCH
   static constexpr integer_type QUILL_CACHE_LINE_MASK{QUILL_CACHE_LINE_SIZE - 1};
+  integer_type _last_flushed_writer_pos{0};
+  integer_type _last_flushed_reader_pos{0};
+#endif
 
   integer_type const _capacity;
   integer_type const _mask;
@@ -336,13 +340,11 @@ private:
 
   alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_writer_pos{0};
   alignas(QUILL_CACHE_LINE_ALIGNED) integer_type _writer_pos{0};
-  integer_type _reader_pos_cache{0};
-  integer_type _last_flushed_writer_pos{0};
+  mutable integer_type _writer_pos_cache{0};
 
   alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_reader_pos{0};
   alignas(QUILL_CACHE_LINE_ALIGNED) integer_type _reader_pos{0};
-  mutable integer_type _writer_pos_cache{0};
-  integer_type _last_flushed_reader_pos{0};
+  integer_type _reader_pos_cache{0};
 };
 
 using BoundedSPSCQueue = BoundedSPSCQueueImpl<size_t>;

--- a/include/quill/core/BoundedSPSCQueue.h
+++ b/include/quill/core/BoundedSPSCQueue.h
@@ -328,8 +328,6 @@ private:
 private:
 #ifdef QUILL_X86ARCH
   static constexpr integer_type QUILL_CACHE_LINE_MASK{QUILL_CACHE_LINE_SIZE - 1};
-  integer_type _last_flushed_writer_pos{0};
-  integer_type _last_flushed_reader_pos{0};
 #endif
 
   integer_type const _capacity;
@@ -340,11 +338,17 @@ private:
 
   alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_writer_pos{0};
   alignas(QUILL_CACHE_LINE_ALIGNED) integer_type _writer_pos{0};
-  mutable integer_type _writer_pos_cache{0};
+  integer_type _reader_pos_cache{0};
+#ifdef QUILL_X86ARCH
+  integer_type _last_flushed_writer_pos{0};
+#endif
 
   alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_reader_pos{0};
   alignas(QUILL_CACHE_LINE_ALIGNED) integer_type _reader_pos{0};
-  integer_type _reader_pos_cache{0};
+  mutable integer_type _writer_pos_cache{0};
+#ifdef QUILL_X86ARCH
+  integer_type _last_flushed_reader_pos{0};
+#endif
 };
 
 using BoundedSPSCQueue = BoundedSPSCQueueImpl<size_t>;


### PR DESCRIPTION
Moves `QUILL_CACHE_LINE_MASK`, `_last_flushed_writer_pos`, and `_last_flushed_reader_pos` inside `#ifdef QUILL_X86ARCH` guards, since they are only referenced within x86-specific cache-line flushing logic. Also regroups the remaining position-tracking members for better locality.

These members serve no purpose on non-x86 targets. Guarding them properly reduces object size on other architectures, prevents accidental misuse outside x86 code paths, and makes the platform-specific intent explicit at a glance.