### PR TITLE
fix rotating sink reopen failure when disk is full

### DIFF
--- a/include/quill/sinks/FileSink.h
+++ b/include/quill/sinks/FileSink.h
@@ -467,6 +467,11 @@ protected:
    */
   void fsync_file(bool force_fsync = false) noexcept
   {
+    if (!_file)
+    {
+      return;
+    }
+
     if (!force_fsync)
     {
       auto const now = std::chrono::steady_clock::now();

--- a/include/quill/sinks/RotatingSink.h
+++ b/include/quill/sinks/RotatingSink.h
@@ -404,7 +404,7 @@ private:
 
     if (!this->_file)
     {
-      this->open_file(this->_filename, _config.open_mode());
+      this->open_file(this->_filename, _reopen_mode_after_failed_rotation(_config.open_mode()));
       _open_file_timestamp = record_timestamp_ns;
       this->_file_size = _get_file_size(this->_filename);
       return;
@@ -659,6 +659,20 @@ private:
       std::sort(_created_files.begin(), _created_files.end(),
                 [](FileInfo const& a, FileInfo const& b) { return a.index < b.index; });
     }
+  }
+
+  /***/
+  QUILL_NODISCARD static std::string _reopen_mode_after_failed_rotation(
+    std::string const& open_mode)
+  {
+    if (!open_mode.empty() && (open_mode.front() == 'w'))
+    {
+      std::string reopen_mode = open_mode;
+      reopen_mode.front() = 'a';
+      return reopen_mode;
+    }
+
+    return open_mode;
   }
 
   /***/

--- a/include/quill/sinks/RotatingSink.h
+++ b/include/quill/sinks/RotatingSink.h
@@ -402,6 +402,14 @@ private:
       return;
     }
 
+    if (!this->_file)
+    {
+      this->open_file(this->_filename, _config.open_mode());
+      _open_file_timestamp = record_timestamp_ns;
+      this->_file_size = _get_file_size(this->_filename);
+      return;
+    }
+
     // We need to flush and also fsync before actually getting the size of the file
     base_type::flush_sink();
     base_type::fsync_file(true);

--- a/test/unit_tests/RotatingFileSinkTest.cpp
+++ b/test/unit_tests/RotatingFileSinkTest.cpp
@@ -9,6 +9,12 @@ TEST_SUITE_BEGIN("RotatingFileSink");
 using namespace quill;
 using namespace quill::detail;
 
+void write_log_statement(RotatingFileSink& sink, std::string_view log_statement)
+{
+  sink.write_log(nullptr, 0, std::string_view{}, std::string_view{}, std::string{},
+                 std::string_view{}, LogLevel::Info, "INFO", "I", nullptr, "", log_statement);
+}
+
 /***/
 TEST_CASE("rotating_file_sink_index_no_backup_limit")
 {
@@ -1929,6 +1935,63 @@ TEST_CASE("rotating_file_sink_index_dont_remove_unrelated_files")
   testing::remove_file(filename_3);
   testing::remove_file(filename_yaml);
   testing::remove_file(filename_other);
+}
+
+/***/
+TEST_CASE("rotating_file_sink_reopen_failure_does_not_crash")
+{
+  fs::path const log_dir = "rotating_file_sink_reopen_failure";
+  fs::path const filename = log_dir / "rotating_file_sink_reopen_failure.log";
+
+  std::error_code ec;
+  fs::remove_all(log_dir, ec);
+  fs::create_directories(log_dir, ec);
+  REQUIRE_FALSE(ec);
+
+  size_t before_open_calls{0};
+  FileEventNotifier file_event_notifier;
+  // Fail the reopen that happens during rotation by removing the parent directory just
+  // before the second open attempt.
+  file_event_notifier.before_open = [&before_open_calls, &log_dir](fs::path const&)
+  {
+    ++before_open_calls;
+    if (before_open_calls == 2)
+    {
+      fs::remove_all(log_dir);
+    }
+  };
+
+  RotatingFileSinkConfig cfg;
+  cfg.set_rotation_max_file_size(512);
+  cfg.set_open_mode('w');
+
+  RotatingFileSink sink{filename, cfg, file_event_notifier};
+  write_log_statement(sink, "Record [0]\n");
+
+  std::string oversized_record = "Record [1]\n";
+  oversized_record.append(600, 'x');
+
+  // The first oversized write triggers rotation and leaves the sink without an open file
+  // when reopen fails.
+  try
+  {
+    write_log_statement(sink, oversized_record);
+  }
+  catch (std::exception const&)
+  {
+  }
+
+  // A second oversized write re-enters the rotation path with a null FILE*.
+  // The current bug dereferences it in fsync_file() and crashes with SIGSEGV.
+  try
+  {
+    write_log_statement(sink, oversized_record);
+  }
+  catch (std::exception const&)
+  {
+  }
+
+  fs::remove_all(log_dir, ec);
 }
 
 /***/

--- a/test/unit_tests/RotatingFileSinkTest.cpp
+++ b/test/unit_tests/RotatingFileSinkTest.cpp
@@ -1938,7 +1938,7 @@ TEST_CASE("rotating_file_sink_index_dont_remove_unrelated_files")
 }
 
 /***/
-TEST_CASE("rotating_file_sink_reopen_failure_does_not_crash")
+TEST_CASE("rotating_file_sink_reopen_failure_does_not_crash_and_recovers_in_append_mode")
 {
   fs::path const log_dir = "rotating_file_sink_reopen_failure";
   fs::path const filename = log_dir / "rotating_file_sink_reopen_failure.log";
@@ -1950,8 +1950,9 @@ TEST_CASE("rotating_file_sink_reopen_failure_does_not_crash")
 
   size_t before_open_calls{0};
   FileEventNotifier file_event_notifier;
-  // Fail the reopen that happens during rotation by removing the parent directory just
-  // before the second open attempt.
+  // Simulate a disk-full style reopen failure during rotation: once the current file
+  // has been renamed away, remove the parent directory just before the reopen attempt
+  // so creating the new active file fails as if no space were available for it.
   file_event_notifier.before_open = [&before_open_calls, &log_dir](fs::path const&)
   {
     ++before_open_calls;
@@ -1965,31 +1966,44 @@ TEST_CASE("rotating_file_sink_reopen_failure_does_not_crash")
   cfg.set_rotation_max_file_size(512);
   cfg.set_open_mode('w');
 
-  RotatingFileSink sink{filename, cfg, file_event_notifier};
-  write_log_statement(sink, "Record [0]\n");
+  {
+    RotatingFileSink sink{filename, cfg, file_event_notifier};
+    write_log_statement(sink, "Record [0]\n");
 
-  std::string oversized_record = "Record [1]\n";
-  oversized_record.append(600, 'x');
+    std::string oversized_record = "Record [1]\n";
+    oversized_record.append(600, 'x');
 
-  // The first oversized write triggers rotation and leaves the sink without an open file
-  // when reopen fails.
-  try
-  {
-    write_log_statement(sink, oversized_record);
-  }
-  catch (std::exception const&)
-  {
+    try
+    {
+      write_log_statement(sink, oversized_record);
+    }
+    catch (std::exception const&)
+    {
+    }
+
+    // A second oversized write re-enters the rotation path with a null FILE*.
+    // The current bug dereferences it in fsync_file() and crashes with SIGSEGV.
+    try
+    {
+      write_log_statement(sink, oversized_record);
+    }
+    catch (std::exception const&)
+    {
+    }
+
+    // Simulate disk cleanup freeing some space while the original active file content
+    // is still on disk. Recovery must reopen in append mode and add new data to this
+    // file instead of truncating and overwriting it.
+    fs::create_directories(log_dir, ec);
+    REQUIRE_FALSE(ec);
+    testing::create_file(filename, "Recovered record\n");
+
+    REQUIRE_NOTHROW(write_log_statement(sink, oversized_record));
   }
 
-  // A second oversized write re-enters the rotation path with a null FILE*.
-  // The current bug dereferences it in fsync_file() and crashes with SIGSEGV.
-  try
-  {
-    write_log_statement(sink, oversized_record);
-  }
-  catch (std::exception const&)
-  {
-  }
+  std::vector<std::string> const file_contents = testing::file_contents(filename);
+  REQUIRE_EQ(testing::file_contains(file_contents, "Recovered record"), true);
+  REQUIRE_EQ(testing::file_contains(file_contents, "Record [1]"), true);
 
   fs::remove_all(log_dir, ec);
 }


### PR DESCRIPTION
Before this fix, a disk-full condition could make log rotation fail while reopening the active log file. That failure left the
rotating sink with a null FILE*, and the next oversized write re-entered the rotation path and unconditionally called fsync_file(), which reached fileno(nullptr) and crashed with SIGSEGV.
