### PR TITLE
fix: avoid max/min macros from colliding with calls to std::numeric_limits<uint32_t>::max()

### DIFF
--- a/include/quill/std/WideString.h
+++ b/include/quill/std/WideString.h
@@ -48,7 +48,7 @@ struct Codec<T,
 
     // The length is stored as uint32_t on the wire. Clamp before casting so a release
     // build cannot truncate-then-overflow when given a pathologically large string.
-    constexpr size_t max_len = std::numeric_limits<uint32_t>::max();
+    constexpr size_t max_len = (std::numeric_limits<uint32_t>::max)();
     QUILL_ASSERT(
       len <= max_len,
       "Wide string length exceeds uint32_t max in Codec<std::wstring>::compute_encoded_size()");


### PR DESCRIPTION
Windows headers (e.g. minwindef.h) define min and max macros which collide with `std::numeric_limits<uint32_t>::max()`.

The C (and therefore C++) preprocessor automatically expands function like macros. i.e. macro identifiers immediately followed by "(".



e.g. 
```c++
#define max(a,b)            (((a) > (b)) ? (a) : (b))

// std::numeric_limits<uint32_t>::max() 
// would result in something like std::numeric_limits<uint32_t>::(((a) > (b)) ? (a) : (b))

// This would be an error in itself because max(a,b) requires two arguments. 
// And even then, this expansion leads to garbage in this case.
```

Thank you for the library!