### PR TITLE
Fix stale file size after deleted-file reopen breaking size-based rotation

### DIFF
--- a/include/quill/sinks/FileSink.h
+++ b/include/quill/sinks/FileSink.h
@@ -383,6 +383,11 @@ public:
     {
       close_file();
       open_file(_filename, _config.open_mode());
+
+      // Resync _file_size with the reopened file; RotatingSink relies on it for size-based rotation
+      ec.clear();
+      auto const reopened_file_size = fs::file_size(_filename, ec);
+      _file_size = ec ? 0 : static_cast<size_t>(reopened_file_size);
     }
   }
 
@@ -687,6 +692,11 @@ public:
     {
       close_file();
       open_file(_filename, _config.open_mode());
+
+      // Resync _file_size with the reopened file; RotatingSink relies on it for size-based rotation
+      ec.clear();
+      auto const reopened_file_size = fs::file_size(_filename, ec);
+      _file_size = ec ? 0 : static_cast<size_t>(reopened_file_size);
     }
   }
 

--- a/test/unit_tests/RotatingFileSinkTest.cpp
+++ b/test/unit_tests/RotatingFileSinkTest.cpp
@@ -305,6 +305,68 @@ TEST_CASE("rotating_file_sink_rename_failure_preserves_current_file_and_state")
   testing::remove_file(filename_1);
 }
 
+/***/
+TEST_CASE("rotating_file_sink_size_rotation_after_deleted_file_reopen")
+{
+#if !defined(_WIN32)
+  // Deleting a file that is still held open requires POSIX semantics
+  fs::path const filename = "rotating_file_sink_size_rotation_after_deleted_file_reopen.log";
+  fs::path const filename_1 = "rotating_file_sink_size_rotation_after_deleted_file_reopen.1.log";
+
+  testing::remove_file(filename);
+  testing::remove_file(filename_1);
+
+  {
+    auto rfh = RotatingFileSink{filename,
+                                []()
+                                {
+                                  RotatingFileSinkConfig cfg;
+                                  cfg.set_rotation_max_file_size(2048);
+                                  cfg.set_open_mode('w');
+                                  return cfg;
+                                }(),
+                                FileEventNotifier{}};
+
+    auto write_record = [&rfh](size_t i)
+    {
+      std::string s{"Record [" + std::to_string(i) + "]"};
+      std::string formatted_log_statement;
+      formatted_log_statement.append(s.data(), s.data() + s.size());
+
+      std::string f;
+      f.resize(590);
+      formatted_log_statement.append(f.data(), f.data() + f.size());
+
+      rfh.write_log(nullptr, 0, std::string_view{}, std::string_view{}, std::string{},
+                    std::string_view{}, LogLevel::Info, "INFO", "I", nullptr, "", formatted_log_statement);
+    };
+
+    write_record(0);
+    rfh.flush_sink();
+
+    // Simulate an external process (e.g. logrotate) deleting the active log file
+    fs::remove(filename);
+
+    write_record(1);
+    rfh.flush_sink(); // detects the deleted file and reopens a fresh one
+
+    // Both records fit inside rotation_max_file_size of the recreated file. A stale
+    // _file_size carried over from before the reopen would trigger a bogus rotation here
+    write_record(2);
+    write_record(3);
+  }
+
+  REQUIRE(fs::exists(filename));
+  REQUIRE_FALSE(fs::exists(filename_1));
+
+  std::vector<std::string> const file_contents = testing::file_contents(filename);
+  REQUIRE_EQ(testing::file_contains(file_contents, "Record [2]"), true);
+  REQUIRE_EQ(testing::file_contains(file_contents, "Record [3]"), true);
+
+  testing::remove_file(filename);
+#endif
+}
+
 TEST_CASE("rotating_json_file_sink_size_rotation_uses_actual_json_size")
 {
   fs::path const estimate_filename = "rotating_json_file_sink_size_rotation_estimate.log";


### PR DESCRIPTION
`FileSink::flush_sink()` has a recovery path: when the log file was deleted externally (e.g. logrotate), it closes the stale handle and reopens a fresh file. That path never resets `_file_size`, so the counter keeps the byte count of the deleted file and keeps growing from there.

`RotatingSink` does not override `flush_sink()` and cannot observe the reopen, so its size check `_file_size + msg_size > rotation_max_file_size` compares against the stale, inflated value and rotates files long before they reach the configured size. The drift compounds with every externally-triggered reopen: rotations fire at ever-smaller real file sizes, churning `max_backup_files` slots (and with `set_overwrite_rolled_files(false)`, prematurely exhausting the rotation budget).

Every other reopen path already maintains this invariant (`RotatingSink` ctor, disk-full recovery, failed-rename recovery, normal rotation) — the `flush_sink()` reopen is the single one that forgets.

The fix re-reads the actual size after reopening, in both the POSIX and Windows variants. `fs::file_size` rather than a hardcoded `0` because an `after_close`/`before_open` file event notifier may legitimately recreate the file with content before the reopen (asserted in the existing `reopen_deleted_file_uses_configured_open_mode` test). Exception-free (`std::error_code` overload), cold path only.

Adds a regression test: after an external delete + reopen, records that fit inside `rotation_max_file_size` must not trigger a rotation.
