### PR TITLE
Publish reader position when the queue drains to avoid permanently blocking near-capacity writes

### DIFF
--- a/include/quill/core/BoundedSPSCQueue.h
+++ b/include/quill/core/BoundedSPSCQueue.h
@@ -198,7 +198,13 @@ public:
 
   QUILL_ATTRIBUTE_HOT void commit_read() noexcept
   {
-    if (static_cast<integer_type>(_reader_pos - _atomic_reader_pos.load(std::memory_order_relaxed)) >= _bytes_per_batch)
+    // Publish the read position when a full batch of _bytes_per_batch was consumed, and also when
+    // the queue is drained as far as the reader knows (_writer_pos_cache == _reader_pos). Without
+    // the drained check, a residual lag smaller than _bytes_per_batch is never released back to
+    // the producer once the queue empties, and a subsequent message that fits in the capacity but
+    // not in (capacity - lag) can never be written
+    if ((static_cast<integer_type>(_reader_pos - _atomic_reader_pos.load(std::memory_order_relaxed)) >= _bytes_per_batch) ||
+        (_writer_pos_cache == _reader_pos))
     {
       _atomic_reader_pos.store(_reader_pos, std::memory_order_release);
 

--- a/test/unit_tests/BoundedQueueTest.cpp
+++ b/test/unit_tests/BoundedQueueTest.cpp
@@ -163,6 +163,29 @@ TEST_CASE("bounded_queue_prepare_write_larger_than_capacity_fails")
   REQUIRE_EQ(buffer.prepare_write(128u), nullptr);
 }
 
+TEST_CASE("bounded_queue_write_after_drain_uses_full_capacity")
+{
+  // default reader_store_percent 5 -> the reader publishes its position every 204 bytes
+  BoundedSPSCQueue buffer{4096u};
+
+  // consume a message smaller than the publish batch, draining the queue
+  std::byte* write_buf = buffer.prepare_write(100u);
+  REQUIRE_NE(write_buf, nullptr);
+  buffer.finish_write(100u);
+  buffer.commit_write();
+
+  std::byte* read_buf = buffer.prepare_read();
+  REQUIRE_NE(read_buf, nullptr);
+  buffer.finish_read(100u);
+  buffer.commit_read();
+
+  // the queue is empty; a message that fits in the capacity must be writable. If the reader
+  // position was not published on drain, the producer permanently sees only (capacity - 100)
+  // free bytes and this write can never succeed
+  REQUIRE_EQ(buffer.prepare_read(), nullptr);
+  REQUIRE_NE(buffer.prepare_write(4000u), nullptr);
+}
+
 #if defined(QUILL_X86ARCH) && !defined(QUILL_NO_EXCEPTIONS)
 TEST_CASE("below_minimum_capacity_throws_before_allocating")
 {


### PR DESCRIPTION
`BoundedSPSCQueueImpl::commit_read()` publishes the reader position only after `_bytes_per_batch` bytes (default 5% of capacity) have been consumed, and the only caller (`BackendWorker::_read_and_decode_frontend_queue`) invokes it only when it read more than zero bytes. So when the queue drains with a residual unpublished lag `L < _bytes_per_batch`, that lag is never released back to the producer: every subsequent poll finds the queue empty, reads nothing, and never calls `commit_read()` again. The producer permanently sees only `capacity - L` free bytes in a completely empty queue.

Consequences for a message of size `capacity - L < n <= capacity`:

- `BoundedBlocking`: the frontend thread spins forever in `_reserve_queue_space` — it can never log again. This contradicts the documented contract in `FrontendOptions.h` ("a single message larger than the fixed queue capacity cannot fit and fails instead of blocking forever" — implying messages that fit must eventually succeed).
- `BoundedDropping`: the message is dropped even though the queue is empty, repeatedly, until unrelated smaller messages happen to push the lag over the batch threshold.
- `Unbounded*` at `unbounded_queue_max_capacity`: same permanent block/drop, since the unbounded consumer delegates to the same `commit_read()`.

The fix also publishes when the queue is drained as far as the reader knows (`_writer_pos_cache == _reader_pos`). Both fields are reader-owned and on the same cache line, so this costs one extra compare — no new atomic loads — and batching is preserved while the queue is busy. Publishing early is always safe as it only exposes fully-consumed positions.

Adds a deterministic regression test: consume a message smaller than the publish batch, then require that a message which fits in the full capacity is writable (fails immediately on regression, no hang).
