### PR TITLE
Fix %s producing UTC-offset-shifted epoch value in GmtTime mode on non-UTC machines

### DIFF
--- a/include/quill/backend/StringFromTime.h
+++ b/include/quill/backend/StringFromTime.h
@@ -77,7 +77,21 @@ public:
     // that are incrementing not those back in time. In this case we just fall back to calling strfime
     if (timestamp < _cached_timestamp)
     {
-      _fallback_formatted = _safe_strftime(_timestamp_format.data(), timestamp, _time_zone).data();
+      // Format part by part so that %s can bypass strftime; strftime's %s round-trips through
+      // mktime() which interprets the broken-down time as local time and produces a
+      // utc-offset-shifted value in GmtTime mode
+      _fallback_formatted.clear();
+      for (auto const& format_part : _initial_parts)
+      {
+        if (format_part == "%s")
+        {
+          _fallback_formatted.append(std::to_string(timestamp));
+        }
+        else
+        {
+          _fallback_formatted.append(_safe_strftime(format_part.data(), timestamp, _time_zone).data());
+        }
+      }
       return _fallback_formatted;
     }
 
@@ -332,10 +346,22 @@ protected:
     // Now run through all parts and call strftime
     for (auto const& format_part : _initial_parts)
     {
+      if (format_part == "%s")
+      {
+        // %s must not go through strftime: strftime converts the broken-down time back to an
+        // epoch value with mktime(), which interprets the fields as local time and produces a
+        // utc-offset-shifted value in GmtTime mode. The epoch value is timezone-independent,
+        // so we format the raw timestamp directly
+        std::string const formatted_epoch = std::to_string(_cached_timestamp);
+        _pre_formatted_ts.append(formatted_epoch);
+        _cached_indexes.emplace_back(_pre_formatted_ts.size() - formatted_epoch.size(), format_type::s);
+        _cached_epoch_seconds_width = formatted_epoch.size();
+        continue;
+      }
+
       // We call strftime on each part of the timestamp to format it.
       std::vector<char> const formatted_part = _safe_strftime(format_part.data(), _cached_timestamp, _time_zone);
       std::string_view const formatted_part_sv{formatted_part.data()};
-      size_t const formatted_part_size = formatted_part_sv.size();
       _pre_formatted_ts.append(formatted_part_sv);
 
       // If we formatted and appended to the string a time modifier also store the
@@ -363,11 +389,6 @@ protected:
       else if (format_part == "%l")
       {
         _cached_indexes.emplace_back(_pre_formatted_ts.size() - 2, format_type::l);
-      }
-      else if (format_part == "%s")
-      {
-        _cached_indexes.emplace_back(_pre_formatted_ts.size() - formatted_part_size, format_type::s);
-        _cached_epoch_seconds_width = formatted_part_size;
       }
     }
   }

--- a/test/unit_tests/StringFromTimeTest.cpp
+++ b/test/unit_tests/StringFromTimeTest.cpp
@@ -1,6 +1,7 @@
 #include "quill/backend/StringFromTime.h"
 #include "DocTestExtensions.h"
 #include "doctest/doctest.h"
+#include <cstdlib>
 #include <ctime>
 #include <limits>
 
@@ -361,12 +362,13 @@ TEST_CASE("string_from_time_gmtime_format_s_crossing_10_digits_preserves_surroun
   {
     auto const& actual = string_from_time.format_timestamp(raw_ts);
 
-    std::tm time_info{};
-    quill::detail::gmtime_rs(&raw_ts, &time_info);
-    char expected[256];
-    std::strftime(expected, sizeof(expected), fmt.data(), &time_info);
+    // %s is timezone-independent, so the expected value is the raw epoch value. Note that
+    // strftime's %s cannot be used as a reference here: it round-trips through mktime() which
+    // interprets the gmtime broken-down time as local time, producing a utc-offset-shifted
+    // value on non-utc machines
+    std::string const expected = "X" + std::to_string(raw_ts) + "Z";
 
-    REQUIRE_STREQ(actual.data(), expected);
+    REQUIRE_STREQ(actual.data(), expected.data());
   }
 #else
   return;
@@ -390,13 +392,65 @@ TEST_CASE("string_from_time_gmtime_format_s_crossing_11_digits_preserves_suffix"
   {
     auto const& actual = string_from_time.format_timestamp(raw_ts);
 
-    std::tm time_info{};
-    quill::detail::gmtime_rs(&raw_ts, &time_info);
-    char expected[256];
-    std::strftime(expected, sizeof(expected), fmt.data(), &time_info);
+    // %s is timezone-independent, so the expected value is the raw epoch value
+    std::string const expected = std::to_string(raw_ts) + "Z";
 
-    REQUIRE_STREQ(actual.data(), expected);
+    REQUIRE_STREQ(actual.data(), expected.data());
   }
+#else
+  return;
+#endif
+}
+
+/***/
+TEST_CASE("string_from_time_gmtime_format_s_non_utc_timezone")
+{
+#if !defined(_WIN32)
+  // %s in GmtTime mode must produce the raw epoch value regardless of the machine's local
+  // timezone. It previously went through strftime, whose %s round-trips the gmtime broken-down
+  // time via mktime() and shifted the value by the utc offset
+  std::string previous_tz;
+  bool had_tz = false;
+  if (char const* current_tz = std::getenv("TZ"))
+  {
+    previous_tz = current_tz;
+    had_tz = true;
+  }
+
+  setenv("TZ", "America/New_York", 1);
+  tzset();
+
+  {
+    std::string fmt = "%s";
+    StringFromTime string_from_time;
+    string_from_time.init(fmt, Timezone::GmtTime);
+
+    time_t const start_ts = 1751884800;
+
+    // first iteration exercises the full recalculation path, the rest the incremental path
+    for (time_t raw_ts = start_ts; raw_ts <= start_ts + 3; ++raw_ts)
+    {
+      auto const& actual = string_from_time.format_timestamp(raw_ts);
+      std::string const expected = std::to_string(raw_ts);
+      REQUIRE_STREQ(actual.data(), expected.data());
+    }
+
+    // also exercise the back-in-time strftime fallback path
+    time_t const back_in_time_ts = start_ts - 100;
+    auto const& fallback_actual = string_from_time.format_timestamp(back_in_time_ts);
+    std::string const fallback_expected = std::to_string(back_in_time_ts);
+    REQUIRE_STREQ(fallback_actual.data(), fallback_expected.data());
+  }
+
+  if (had_tz)
+  {
+    setenv("TZ", previous_tz.c_str(), 1);
+  }
+  else
+  {
+    unsetenv("TZ");
+  }
+  tzset();
 #else
   return;
 #endif


### PR DESCRIPTION
`StringFromTime` formats the `%s` specifier through `strftime()`. libc's `%s` converts the broken-down `tm` back to an epoch value via `mktime()`, which interprets the fields as local time — so in `Timezone::GmtTime` mode (where the `tm` came from `gmtime_r()`) the produced value is `timestamp ± utc_offset`. Verified on macOS; glibc's `strftime` implements `%s` the same way.

On any machine whose local timezone is not UTC this causes:

- The full-recalculation path (every noon/midnight) and the back-in-time fallback path print the offset-shifted value, while the incremental path writes the raw (correct) `_cached_timestamp` into the same slot — the logged epoch column jumps back and forth by the UTC offset within a monotonically increasing stream.
- `_cached_epoch_seconds_width` is derived from the wrong value's digit count; when it disagrees with the real timestamp's width, the width-mismatch guard forces a full recalculation on every single call — a permanent slow path that also prints the wrong value every time.

The two existing GMT `%s` unit tests encode the buggy value as the expectation (they compare against `strftime`), so they currently fail on any non-UTC dev machine; CI never catches it because GitHub runners run with `TZ=UTC`.

Since `%s` is timezone-independent by definition — it *is* the raw timestamp the class already holds — the fix formats it directly and never routes it through `strftime`, in both the pre-formatted-string population and the back-in-time fallback (which now formats part by part; per-part `strftime` concatenation is equivalent to whole-string `strftime` as parts are split at conversion-specifier boundaries, and the path is cold). `LocalTime` mode is unaffected: the `mktime` round-trip is correct there and identical to printing the raw epoch.

Updates the two existing GMT `%s` tests to compare against the timezone-independent expected value, and adds a regression test that sets `TZ=America/New_York` and exercises the recalculation, incremental, and fallback paths.
