### PR TITLE
fix build  error no match for 'operator~' on i386.

### DIFF
--- a/include/quill/bundled/fmt/format.h
+++ b/include/quill/bundled/fmt/format.h
@@ -376,8 +376,8 @@ class uint128 {
     lo_ &= n.lo_;
     hi_ &= n.hi_;
   }
-  FMTQUILL_CONSTEXPR auto operator~() -> uint128 {
-    return uint128(~hi_, ~lo_);
+  friend constexpr auto operator~(const uint128& n) -> uint128 {
+    return {~n.hi_, ~n.lo_};
   }
 
   FMTQUILL_CONSTEXPR20 auto operator+=(uint64_t n) noexcept -> uint128& {

--- a/include/quill/bundled/fmt/format.h
+++ b/include/quill/bundled/fmt/format.h
@@ -376,6 +376,9 @@ class uint128 {
     lo_ &= n.lo_;
     hi_ &= n.hi_;
   }
+  FMTQUILL_CONSTEXPR auto operator~() -> uint128 {
+    return uint128(~hi_, ~lo_);
+  }
 
   FMTQUILL_CONSTEXPR20 auto operator+=(uint64_t n) noexcept -> uint128& {
     if (is_constant_evaluated()) {


### PR DESCRIPTION
Build failure on i386 with new fmt version.
```
make
[  0%] Built target quill
[  1%] Building CXX object test/misc/CMakeFiles/quill_test_common.dir/TestMain.cpp.o
[  1%] Building CXX object test/misc/CMakeFiles/quill_test_common.dir/TestUtilities.cpp.o
[  1%] Building CXX object test/misc/CMakeFiles/quill_test_common.dir/DocTestExtensions.cpp.o
[  2%] Linking CXX static library libquill_test_common.a
[  2%] Built target quill_test_common
[  2%] Building CXX object test/unit_tests/CMakeFiles/TEST_BackendWorkerLock.dir/BackendWorkerLockTest.cpp.o
[  3%] Linking CXX executable ../../build/test/TEST_BackendWorkerLock
[  3%] Built target TEST_BackendWorkerLock
[  3%] Building CXX object test/unit_tests/CMakeFiles/TEST_BoundedQueueTest.dir/BoundedQueueTest.cpp.o
[  4%] Linking CXX executable ../../build/test/TEST_BoundedQueueTest
[  4%] Built target TEST_BoundedQueueTest
[  4%] Building CXX object test/unit_tests/CMakeFiles/TEST_BacktraceStorage.dir/BacktraceStorageTest.cpp.o
In file included from /home/algorist/repo/quill/include/quill/backend/TransitEvent.h:14,
                 from /home/algorist/repo/quill/include/quill/backend/BacktraceStorage.h:9,
                 from /home/algorist/repo/quill/test/unit_tests/BacktraceStorageTest.cpp:3:
/home/algorist/repo/quill/include/quill/bundled/fmt/format.h: In instantiation of 'void fmtquill::v12::detail::format_hexfloat(Float, fmtquill::v12::format_specs, buffer<char>&) [with Float = long double; typename std::enable_if<(! std::integral_constant<bool, (std::numeric_limits<_Tp>::digits == 106)>::value), int>::type <anonymous> = 0]':
/home/algorist/repo/quill/include/quill/bundled/fmt/format.h:3517:20:   required from 'OutputIt fmtquill::v12::detail::write(OutputIt, T, fmtquill::v12::format_specs, fmtquill::v12::locale_ref) [with Char = char; OutputIt = fmtquill::v12::basic_appender<char>; T = long double; typename std::enable_if<is_floating_point<T>::value, int>::type <anonymous> = 0]'
 3517 |     format_hexfloat(convert_float(value), specs, buffer);
      |     ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/algorist/repo/quill/include/quill/bundled/fmt/format.h:3611:21:   required from 'OutputIt fmtquill::v12::detail::write(OutputIt, T) [with Char = char; OutputIt = fmtquill::v12::basic_appender<char>; T = long double; typename std::enable_if<(is_floating_point<T>::value && (! is_fast_float<T>::value)), int>::type <anonymous> = 0]'
 3611 |   return write<Char>(out, value, {});
      |          ~~~~~~~~~~~^~~~~~~~~~~~~~~~
/home/algorist/repo/quill/include/quill/bundled/fmt/format.h:3701:16:   required from 'void fmtquill::v12::detail::default_arg_formatter<Char>::operator()(T) [with T = long double; typename std::enable_if<std::integral_constant<bool, (std::is_same<T, int>::value || 1)>::value, int>::type <anonymous> = 0; Char = char]'
 3701 |     write<Char>(out, value);
      |     ~~~~~~~~~~~^~~~~~~~~~~~
/home/algorist/repo/quill/include/quill/bundled/fmt/base.h:2530:52:   required from 'constexpr decltype (vis(0)) fmtquill::v12::basic_format_arg<Context>::visit(Visitor&&) const [with Visitor = fmtquill::v12::detail::default_arg_formatter<char>; Context = fmtquill::v12::context; decltype (vis(0)) = void]'
 2530 |     case detail::type::long_double_type: return vis(value_.long_double_value);
      |                                                 ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/algorist/repo/quill/include/quill/bundled/fmt/format-inl.h:1471:29:   required from here
 1471 |     return args.get(0).visit(default_arg_formatter<char>{out});
      |            ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/algorist/repo/quill/include/quill/bundled/fmt/format.h:3124:14: error: no match for 'operator~' (operand type is 'fmtquill::v12::detail::uint128')
 3124 |       f.f &= ~(inc - 1);
      |              ^~~~~~~~~~
make[2]: *** [test/unit_tests/CMakeFiles/TEST_BacktraceStorage.dir/build.make:79: test/unit_tests/CMakeFiles/TEST_BacktraceStorage.dir/BacktraceStorageTest.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:806: test/unit_tests/CMakeFiles/TEST_BacktraceStorage.dir/all] Error 2
make: *** [Makefile:166: all] Error 2

```