### PR TITLE
Fix QUILL_X86ARCH build with generic -march levels

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -83,6 +83,16 @@ jobs:
             with_tests: ON
             cmake_options: -DQUILL_NO_EXCEPTIONS=ON
 
+            # Builds and tests the x86 cache-coherence code paths
+          - cxx: g++-14
+            build_type: Release
+            std: 20
+            os: ubuntu-24.04
+            with_tests: ON
+            cmake_options: -DQUILL_X86ARCH=ON
+            cxxflags: -march=x86-64-v3
+            install: sudo apt -o Acquire::Retries=5 install g++-14
+
             # Build and test with valgrind
           - cxx: g++-10
             build_type: Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,9 @@
 - Repeated backend error notifications are now rate-limited.
 - Fixed duplicate flushes when multiple threads share a logger configured with
   `set_immediate_flush(N)` where `N > 1`.
+- Fixed `QUILL_X86ARCH` builds failing to compile with the generic `-march=x86-64-v2`, `-march=x86-64-v3`
+  and `-march=x86-64-v4` levels, none of which enable `clflushopt`. The cache-line flush now falls back
+  to `clflush` when the compiler reports no `clflushopt` support.
 
 ## v12.1.0
 

--- a/include/quill/core/BoundedSPSCQueue.h
+++ b/include/quill/core/BoundedSPSCQueue.h
@@ -253,6 +253,23 @@ public:
 
 private:
 #if defined(QUILL_X86ARCH)
+  /**
+   * Flush a single cache line.
+   *
+   * clflushopt is a separate CPU feature rather than a part of any x86-64 microarchitecture
+   * level, so -march=x86-64-v2/v3/v4 do not enable it and the compiler rejects the always_inline
+   * intrinsic. Fall back to clflush, which is SSE2 baseline and is already used unconditionally
+   * by the constructor, when the compiler reports no clflushopt support.
+   */
+  QUILL_ATTRIBUTE_HOT static void _flush_cacheline(void* address) noexcept
+  {
+  #if defined(__CLFLUSHOPT__) || (defined(_MSC_VER) && !defined(__GNUC__) && !defined(__clang__))
+    _mm_clflushopt(address);
+  #else
+    _mm_clflush(address);
+  #endif
+  }
+
   QUILL_ATTRIBUTE_HOT void _flush_cachelines(integer_type& last, integer_type offset)
   {
     integer_type last_diff = last - (last & QUILL_CACHE_LINE_MASK);
@@ -262,7 +279,7 @@ private:
     {
       do
       {
-        _mm_clflushopt(_storage + (last_diff & _mask));
+        _flush_cacheline(_storage + (last_diff & _mask));
         last_diff += QUILL_CACHE_LINE_SIZE;
       } while (cur_diff > last_diff);
 

--- a/test/unit_tests/BoundedQueueTest.cpp
+++ b/test/unit_tests/BoundedQueueTest.cpp
@@ -143,11 +143,13 @@ TEST_CASE("bounded_queue_read_write_multithreaded_plain_ints")
 
 TEST_CASE("bounded_queue_prepare_write_larger_than_capacity_fails")
 {
-  BoundedSPSCQueue buffer{64u};
+  // 1024 is the minimum capacity accepted under QUILL_X86ARCH, so this test runs unchanged in
+  // both configurations
+  BoundedSPSCQueue buffer{1024u};
 
-  REQUIRE_EQ(buffer.capacity(), 64u);
-  REQUIRE_EQ(buffer.prepare_write(65u), nullptr);
-  REQUIRE_EQ(buffer.prepare_write(128u), nullptr);
+  REQUIRE_EQ(buffer.capacity(), 1024u);
+  REQUIRE_EQ(buffer.prepare_write(1025u), nullptr);
+  REQUIRE_EQ(buffer.prepare_write(2048u), nullptr);
 
   std::byte* write_buf = buffer.prepare_write(32u);
   REQUIRE_NE(write_buf, nullptr);
@@ -159,8 +161,8 @@ TEST_CASE("bounded_queue_prepare_write_larger_than_capacity_fails")
   buffer.finish_read(32u);
   buffer.commit_read();
 
-  REQUIRE_EQ(buffer.prepare_write(65u), nullptr);
-  REQUIRE_EQ(buffer.prepare_write(128u), nullptr);
+  REQUIRE_EQ(buffer.prepare_write(1025u), nullptr);
+  REQUIRE_EQ(buffer.prepare_write(2048u), nullptr);
 }
 
 TEST_CASE("bounded_queue_write_after_drain_uses_full_capacity")


### PR DESCRIPTION
`QUILL_X86ARCH` does not compile with any of the generic `-march=x86-64-v2/v3/v4`
levels, including the `-march=x86-64-v3` the README documents for benchmark builds:

```
clflushoptintrin.h:39:1: error: inlining failed in call to 'always_inline'
'void _mm_clflushopt(void*)': target specific option mismatch
include/quill/core/BoundedSPSCQueue.h:265:23: note: called from here
```

`clflushopt` is a separate CPU feature bit rather than a part of any x86-64
microarchitecture level, so GCC and clang only make the intrinsic usable when
`-mclflushopt` is active, or an `-march` that implies it such as `skylake` or `native`.

### Changes

- `BoundedSPSCQueue.h`: the cache-line flush now goes through a `_flush_cacheline()`
  helper that uses `clflushopt` when the compiler reports support for it and falls back
  to `clflush` otherwise. `clflush` is SSE2 baseline and is already called
  unconditionally by the constructor, so the fallback is always available. Builds that
  already enable `clflushopt` are unaffected.
- `BoundedQueueTest.cpp`: `bounded_queue_prepare_write_larger_than_capacity_fails` built
  a queue with capacity 64, which `_validate_capacity()` rejects under `QUILL_X86ARCH`
  (minimum 1024). Raised to 1024 so the test runs in both configurations instead of
  being excluded.
- `ubuntu.yml`: added a matrix entry that builds and runs the tests with
  `-DQUILL_X86ARCH=ON` and `-march=x86-64-v3`, using the existing `cxxflags` key.
  `QUILL_X86ARCH` had no CI coverage, which is why neither problem showed up.

### Verification

Compiling and running the x86 queue paths. The before column is g++ 14.4; the after
column was checked with both g++ 14.4 and clang 19.1.7:

| `-march` | before | after |
| --- | --- | --- |
| none, `x86-64`, `x86-64-v2`, `x86-64-v3`, `x86-64-v4`, `haswell` | build error | ok |
| `skylake`, `native`, `x86-64-v3 -mclflushopt` | ok | ok |

Emitted instructions, confirming the generated code is unchanged wherever `clflushopt`
is available:

| build | `clflushopt` | `clflush` |
| --- | --- | --- |
| `-march=x86-64-v3` | 0 | 3 |
| `-march=x86-64-v3 -mclflushopt` | 2 | 1 |
| `-march=native` | 2 | 1 |

`ctest`, all passing:

| configuration | result |
| --- | --- |
| `Release`, baseline | 415/415 |
| `Release`, `QUILL_X86ARCH`, `-march=x86-64-v3` | 414/414 |
| `Release`, `QUILL_X86ARCH`, `-march=native` | 414/414 |
| `Debug`, `QUILL_X86ARCH`, `-march=x86-64-v3` | 414/414 |
| `Release`, clang, `QUILL_X86ARCH`, `-march=x86-64-v3` | 414/414 |

The 415 vs 414 difference is expected: the two capacity-64 test cases are excluded under
`QUILL_X86ARCH`, and `below_minimum_capacity_throws_before_allocating` is added.
