### PR TITLE
Remove the QUILL_X86ARCH build option

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -83,16 +83,6 @@ jobs:
             with_tests: ON
             cmake_options: -DQUILL_NO_EXCEPTIONS=ON
 
-            # Builds and tests the x86 cache-coherence code paths
-          - cxx: g++-14
-            build_type: Release
-            std: 20
-            os: ubuntu-24.04
-            with_tests: ON
-            cmake_options: -DQUILL_X86ARCH=ON
-            cxxflags: -march=x86-64-v3
-            install: sudo apt -o Acquire::Retries=5 install g++-14
-
             # Build and test with valgrind
           - cxx: g++-10
             build_type: Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,9 +112,9 @@
 - Repeated backend error notifications are now rate-limited.
 - Fixed duplicate flushes when multiple threads share a logger configured with
   `set_immediate_flush(N)` where `N > 1`.
-- Fixed `QUILL_X86ARCH` builds failing to compile with the generic `-march=x86-64-v2`, `-march=x86-64-v3`
-  and `-march=x86-64-v4` levels, none of which enable `clflushopt`. The cache-line flush now falls back
-  to `clflush` when the compiler reports no `clflushopt` support.
+- Removed the `QUILL_X86ARCH` build option along with the x86 cache-line flush and prefetch code it
+  enabled. Benchmarks on Intel and AMD systems across several thread-pinning topologies showed the
+  option consistently increased producer-side latency with no measurable benefit.
 
 ## v12.1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ option(QUILL_NO_THREAD_NAME_SUPPORT "Enable this option to disable features that
 
 option(QUILL_USE_SEQUENTIAL_THREAD_ID "Enable this option to use a sequential counter for thread IDs instead of OS-assigned thread IDs. Requires defining QUILL_DEFINE_SEQUENTIAL_THREAD_ID (from quill/Utility.h) in exactly one translation unit." OFF)
 
-option(QUILL_X86ARCH "Enable x86-specific optimizations for cache coherence using _mm_prefetch, _mm_clflush, and _mm_clflushopt instructions. Ensure the target architecture must also be specified with -march=\"...\" when enabling this option." OFF)
-
 option(QUILL_DISABLE_NON_PREFIXED_MACROS "Enable this option to disable non-prefixed `LOG_*` macros, keeping only the `QUILL_LOG_*` macros to avoid conflicts with other logging libraries." OFF)
 
 option(QUILL_DISABLE_FUNCTION_NAME "Disable the use of __FUNCTION__ in `LOG_*` macros when the function name is not needed." OFF)
@@ -133,7 +131,6 @@ endif ()
 message(STATUS "QUILL_NO_EXCEPTIONS: " ${QUILL_NO_EXCEPTIONS})
 message(STATUS "QUILL_NO_THREAD_NAME_SUPPORT: " ${QUILL_NO_THREAD_NAME_SUPPORT})
 message(STATUS "QUILL_USE_SEQUENTIAL_THREAD_ID: " ${QUILL_USE_SEQUENTIAL_THREAD_ID})
-message(STATUS "QUILL_X86ARCH: " ${QUILL_X86ARCH})
 message(STATUS "QUILL_DISABLE_NON_PREFIXED_MACROS: " ${QUILL_DISABLE_NON_PREFIXED_MACROS})
 message(STATUS "QUILL_DISABLE_FUNCTION_NAME: " ${QUILL_DISABLE_FUNCTION_NAME})
 message(STATUS "QUILL_DETAILED_FUNCTION_NAME: " ${QUILL_DETAILED_FUNCTION_NAME})
@@ -329,10 +326,6 @@ endif ()
 
 if (QUILL_USE_SEQUENTIAL_THREAD_ID)
     target_compile_definitions(${TARGET_NAME} INTERFACE -DQUILL_USE_SEQUENTIAL_THREAD_ID)
-endif ()
-
-if (QUILL_X86ARCH)
-    target_compile_definitions(${TARGET_NAME} INTERFACE -DQUILL_X86ARCH)
 endif ()
 
 if (QUILL_DISABLE_NON_PREFIXED_MACROS)

--- a/include/quill/core/BoundedSPSCQueue.h
+++ b/include/quill/core/BoundedSPSCQueue.h
@@ -28,25 +28,6 @@
   #endif
 #endif
 
-#if defined(QUILL_X86ARCH)
-  #if defined(_WIN32)
-    #include <intrin.h>
-  #else
-    #if __has_include(<x86gprintrin.h>)
-      #if defined(__GNUC__) && __GNUC__ > 10
-        #include <emmintrin.h>
-        #include <x86gprintrin.h>
-      #elif defined(__clang_major__)
-      // clang needs immintrin for _mm_clflushopt
-        #include <immintrin.h>
-      #endif
-    #else
-      #include <immintrin.h>
-      #include <x86intrin.h>
-    #endif
-  #endif
-#endif
-
 QUILL_BEGIN_NAMESPACE
 
 namespace detail
@@ -95,21 +76,6 @@ public:
 
     // reader_pos starts at 0, so cached value is 0 + capacity
     _reader_pos_cache_plus_capacity = _capacity;
-
-#if defined(QUILL_X86ARCH)
-    // remove log memory from cache
-    for (size_t i = 0; i < storage_size; i += QUILL_CACHE_LINE_SIZE)
-    {
-      _mm_clflush(_storage + i);
-    }
-
-    uint64_t const cache_lines = (_capacity >= 2048) ? 32 : 16;
-
-    for (uint64_t i = 0; i < cache_lines; ++i)
-    {
-      _mm_prefetch(reinterpret_cast<char const*>(_storage + (QUILL_CACHE_LINE_SIZE * i)), _MM_HINT_T0);
-    }
-#endif
   }
 
   ~BoundedSPSCQueueImpl() { _free_aligned(_storage); }
@@ -158,15 +124,6 @@ public:
   {
     // set the atomic flag so the reader can see write
     _atomic_writer_pos.store(_writer_pos, std::memory_order_release);
-
-#if defined(QUILL_X86ARCH)
-    // flush writen cache lines
-    _flush_cachelines(_last_flushed_writer_pos, _writer_pos);
-
-    // prefetch a future cache line
-    _mm_prefetch(
-      reinterpret_cast<char const*>(_storage + ((_writer_pos + QUILL_CACHE_LINE_SIZE * 10) & _mask)), _MM_HINT_T0);
-#endif
   }
 
   /**
@@ -183,15 +140,6 @@ public:
 
     // set the atomic flag so the reader can see write
     _atomic_writer_pos.store(new_writer_pos, std::memory_order_release);
-
-#if defined(QUILL_X86ARCH)
-    // flush writen cache lines
-    _flush_cachelines(_last_flushed_writer_pos, new_writer_pos);
-
-    // prefetch a future cache line
-    _mm_prefetch(
-      reinterpret_cast<char const*>(_storage + ((new_writer_pos + QUILL_CACHE_LINE_SIZE * 10) & _mask)), _MM_HINT_T0);
-#endif
   }
 
   QUILL_NODISCARD QUILL_ATTRIBUTE_HOT std::byte* prepare_read() noexcept
@@ -217,10 +165,6 @@ public:
         (_writer_pos_cache == _reader_pos))
     {
       _atomic_reader_pos.store(_reader_pos, std::memory_order_release);
-
-#if defined(QUILL_X86ARCH)
-      _flush_cachelines(_last_flushed_reader_pos, _reader_pos);
-#endif
     }
   }
 
@@ -252,42 +196,6 @@ public:
   QUILL_NODISCARD HugePagesPolicy huge_pages_policy() const noexcept { return _huge_pages_policy; }
 
 private:
-#if defined(QUILL_X86ARCH)
-  /**
-   * Flush a single cache line.
-   *
-   * clflushopt is a separate CPU feature rather than a part of any x86-64 microarchitecture
-   * level, so -march=x86-64-v2/v3/v4 do not enable it and the compiler rejects the always_inline
-   * intrinsic. Fall back to clflush, which is SSE2 baseline and is already used unconditionally
-   * by the constructor, when the compiler reports no clflushopt support.
-   */
-  QUILL_ATTRIBUTE_HOT static void _flush_cacheline(void* address) noexcept
-  {
-  #if defined(__CLFLUSHOPT__) || (defined(_MSC_VER) && !defined(__GNUC__) && !defined(__clang__))
-    _mm_clflushopt(address);
-  #else
-    _mm_clflush(address);
-  #endif
-  }
-
-  QUILL_ATTRIBUTE_HOT void _flush_cachelines(integer_type& last, integer_type offset)
-  {
-    integer_type last_diff = last - (last & QUILL_CACHE_LINE_MASK);
-    integer_type const cur_diff = offset - (offset & QUILL_CACHE_LINE_MASK);
-
-    if (cur_diff > last_diff)
-    {
-      do
-      {
-        _flush_cacheline(_storage + (last_diff & _mask));
-        last_diff += QUILL_CACHE_LINE_SIZE;
-      } while (cur_diff > last_diff);
-
-      last = last_diff;
-    }
-  }
-#endif
-
   /**
    * align a pointer to the given alignment
    * @param pointer a pointer the object
@@ -315,18 +223,9 @@ private:
   /**
    * Validate the requested capacity before any allocation happens. Called from the member
    * initialiser list so that a bad argument throws before mmap/aligned_malloc leaks memory.
-   * The 1024-byte minimum exists on x86 because the constructor warms up cache lines via
-   * _mm_prefetch and assumes the backing region is at least that large.
    */
   static integer_type _validate_capacity(QUILL_MAYBE_UNUSED integer_type capacity)
   {
-#if defined(QUILL_X86ARCH)
-    if (capacity < 1024)
-    {
-      QUILL_THROW(QuillError{"Capacity must be at least 1024"});
-    }
-#endif
-
     size_t const rounded_capacity = next_power_of_two(static_cast<size_t>(capacity));
 
     constexpr auto max_integer_capacity = []() constexpr
@@ -462,8 +361,6 @@ private:
   }
 
 private:
-  static constexpr integer_type QUILL_CACHE_LINE_MASK{QUILL_CACHE_LINE_SIZE - 1};
-
   integer_type const _capacity;
   integer_type const _mask;
   integer_type const _bytes_per_batch;
@@ -473,12 +370,10 @@ private:
   alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_writer_pos{0};
   alignas(QUILL_CACHE_LINE_ALIGNED) integer_type _writer_pos{0};
   integer_type _reader_pos_cache_plus_capacity{0};
-  integer_type _last_flushed_writer_pos{0};
 
   alignas(QUILL_CACHE_LINE_ALIGNED) std::atomic<integer_type> _atomic_reader_pos{0};
   alignas(QUILL_CACHE_LINE_ALIGNED) integer_type _reader_pos{0};
   mutable integer_type _writer_pos_cache{0};
-  integer_type _last_flushed_reader_pos{0};
 };
 
 using BoundedSPSCQueue = BoundedSPSCQueueImpl<size_t>;

--- a/test/unit_tests/BoundedQueueTest.cpp
+++ b/test/unit_tests/BoundedQueueTest.cpp
@@ -18,9 +18,6 @@ TEST_SUITE_BEGIN("BoundedQueue");
 
 using namespace quill::detail;
 
-#if !defined(QUILL_X86ARCH)
-// QUILL_X86ARCH requires at least a queue capacity of 1024 and those tests are using a smaller number
-
 TEST_CASE("read_write_buffer")
 {
   BoundedSPSCQueue buffer{64u};
@@ -87,7 +84,6 @@ TEST_CASE("bounded_queue_integer_overflow")
     buffer.commit_read();
   }
 }
-#endif
 
 TEST_CASE("bounded_queue_read_write_multithreaded_plain_ints")
 {
@@ -143,13 +139,11 @@ TEST_CASE("bounded_queue_read_write_multithreaded_plain_ints")
 
 TEST_CASE("bounded_queue_prepare_write_larger_than_capacity_fails")
 {
-  // 1024 is the minimum capacity accepted under QUILL_X86ARCH, so this test runs unchanged in
-  // both configurations
-  BoundedSPSCQueue buffer{1024u};
+  BoundedSPSCQueue buffer{64u};
 
-  REQUIRE_EQ(buffer.capacity(), 1024u);
-  REQUIRE_EQ(buffer.prepare_write(1025u), nullptr);
-  REQUIRE_EQ(buffer.prepare_write(2048u), nullptr);
+  REQUIRE_EQ(buffer.capacity(), 64u);
+  REQUIRE_EQ(buffer.prepare_write(65u), nullptr);
+  REQUIRE_EQ(buffer.prepare_write(128u), nullptr);
 
   std::byte* write_buf = buffer.prepare_write(32u);
   REQUIRE_NE(write_buf, nullptr);
@@ -161,8 +155,8 @@ TEST_CASE("bounded_queue_prepare_write_larger_than_capacity_fails")
   buffer.finish_read(32u);
   buffer.commit_read();
 
-  REQUIRE_EQ(buffer.prepare_write(1025u), nullptr);
-  REQUIRE_EQ(buffer.prepare_write(2048u), nullptr);
+  REQUIRE_EQ(buffer.prepare_write(65u), nullptr);
+  REQUIRE_EQ(buffer.prepare_write(128u), nullptr);
 }
 
 TEST_CASE("bounded_queue_write_after_drain_uses_full_capacity")
@@ -187,21 +181,6 @@ TEST_CASE("bounded_queue_write_after_drain_uses_full_capacity")
   REQUIRE_EQ(buffer.prepare_read(), nullptr);
   REQUIRE_NE(buffer.prepare_write(4000u), nullptr);
 }
-
-#if defined(QUILL_X86ARCH) && !defined(QUILL_NO_EXCEPTIONS)
-TEST_CASE("below_minimum_capacity_throws_before_allocating")
-{
-  // On x86 the constructor requires at least 1024 bytes so that cache-line warmup via
-  // _mm_prefetch has enough backing memory. The capacity check must run in the member
-  // initialiser list BEFORE mmap/aligned_malloc happens, otherwise the allocation would
-  // leak (the destructor does not run on a partially-constructed object).
-  REQUIRE_THROWS_AS(BoundedSPSCQueue{512u}, quill::QuillError);
-  REQUIRE_THROWS_AS(BoundedSPSCQueue{1023u}, quill::QuillError);
-
-  // Exactly 1024 is the documented minimum and must succeed.
-  REQUIRE_NOTHROW(BoundedSPSCQueue{1024u});
-}
-#endif
 
 #if !defined(QUILL_NO_EXCEPTIONS)
 TEST_CASE("oversized_capacity_throws_before_allocating")


### PR DESCRIPTION
Follow-up to #966, as discussed there.

### Removed

- `BoundedSPSCQueue.h`: the intrinsic includes, the constructor's `clflush` and `_mm_prefetch`
  warmup, the flush and prefetch in `commit_write()`,
  `finish_and_commit_write_reservation()` and `commit_read()`, and the `_flush_cacheline()` /
  `_flush_cachelines()` helpers. `QUILL_CACHE_LINE_MASK`, `_last_flushed_writer_pos` and
  `_last_flushed_reader_pos` were only used by that code, so they go with it.
- The 1024-byte minimum in `_validate_capacity()`. It existed only so the constructor's
  prefetch warmup had enough backing memory. The rest of the validation — power-of-two
  rounding, integer-type and allocation-size limits — is unchanged.
- `CMakeLists.txt`: the option, its status message, and the `target_compile_definitions` block.
- `.github/workflows/ubuntu.yml`: the matrix entry added in #966.
- `BoundedQueueTest.cpp`: the `#if !defined(QUILL_X86ARCH)` guard, so `read_write_buffer` and
  `bounded_queue_integer_overflow` now build unconditionally, and
  `below_minimum_capacity_throws_before_allocating`, which only covered the removed minimum.
  `bounded_queue_prepare_write_larger_than_capacity_fails` goes back to a capacity of 64, so it
  matches the other small-capacity cases again.

`README.md` and `docs/` never referenced the option, so nothing to update there.

### Changelog

I replaced the `QUILL_X86ARCH` line added by #966 rather than adding a second one: both land in
the same unreleased v12.2.0, so a reader of the release notes would otherwise see a compatibility
fix for an option that no longer exists. Happy to keep both if you would rather. The mentions in
older released sections are untouched.

### Existing users

Passing `-DQUILL_X86ARCH=ON` no longer fails, it is just ignored:

```
CMake Warning:
  Manually-specified variables were not used by the project:

    QUILL_X86ARCH
```

### Verification

`ctest`, all passing:

| configuration | result |
| --- | --- |
| `Release`, g++ 14.4 | 415/415 |
| `Debug`, g++ 14.4 | 415/415 |
| `Release`, clang 19.1.7 | 415/415 |
| `Release`, `-march=x86-64-v3` | 415/415 |
| `Release`, with a stale `-DQUILL_X86ARCH=ON` | 415/415 |
