### PR TITLE
Fix empty filename timestamp expansions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@
 
 ## v13.1.0
 
+- `FileSink` now accepts custom filename timestamp formats that expand to an empty string, such as
+  `%p` in locales without AM/PM markers.
 - Loggers using `ClockSourceType::System` no longer stall behind the timestamp-ordering grace check
   after a backward wall-clock correction.
 - `RotatingFileSink` now recognizes existing backup filename aliases during startup, preserving

--- a/include/quill/sinks/FileSink.h
+++ b/include/quill/sinks/FileSink.h
@@ -288,13 +288,15 @@ protected:
     static constexpr size_t buffer_size{128};
     static constexpr size_t max_buffer_size{64 * 1024};
     std::vector<char> buffer(buffer_size);
+    // A prefix distinguishes an empty expansion from an insufficient buffer.
+    std::string const format_with_prefix{"x" + append_format_pattern};
 
     while (true)
     {
-      size_t const len = std::strftime(buffer.data(), buffer.size(), append_format_pattern.data(), &now_tm);
+      size_t const len = std::strftime(buffer.data(), buffer.size(), format_with_prefix.c_str(), &now_tm);
       if (len != 0)
       {
-        return std::string{buffer.data(), len};
+        return std::string{buffer.data() + 1, len - 1};
       }
 
       if (buffer.size() >= max_buffer_size)
@@ -885,13 +887,15 @@ protected:
     static constexpr size_t buffer_size{128};
     static constexpr size_t max_buffer_size{64 * 1024};
     std::vector<char> buffer(buffer_size);
+    // A prefix distinguishes an empty expansion from an insufficient buffer.
+    std::string const format_with_prefix{"x" + append_format_pattern};
 
     while (true)
     {
-      size_t const len = std::strftime(buffer.data(), buffer.size(), append_format_pattern.data(), &now_tm);
+      size_t const len = std::strftime(buffer.data(), buffer.size(), format_with_prefix.c_str(), &now_tm);
       if (len != 0)
       {
-        return std::string{buffer.data(), len};
+        return std::string{buffer.data() + 1, len - 1};
       }
 
       if (buffer.size() >= max_buffer_size)

--- a/test/unit_tests/FileSinkTest.cpp
+++ b/test/unit_tests/FileSinkTest.cpp
@@ -6,6 +6,8 @@
 #include "quill/core/DynamicFormatArgStore.h"
 #include "quill/sinks/FileSink.h"
 
+#include <clocale>
+
 #if !defined(_WIN32)
   #include <unistd.h>
 #endif
@@ -198,6 +200,40 @@ TEST_CASE("append_custom_timestamp_to_file")
   }
 
   testing::remove_file(expected_filename);
+}
+
+/***/
+TEST_CASE("append_custom_timestamp_with_empty_locale_expansion")
+{
+  struct ScopedLcTime
+  {
+    std::string previous{std::setlocale(LC_TIME, nullptr)};
+    ~ScopedLcTime() { std::setlocale(LC_TIME, previous.c_str()); }
+  } scoped_lc_time;
+
+  if (std::setlocale(LC_TIME, "fr_FR.UTF-8") == nullptr)
+  {
+    return;
+  }
+
+  std::tm time_info{};
+  char am_pm[32];
+  if (std::strftime(am_pm, sizeof(am_pm), "%p", &time_info) != 0)
+  {
+    return;
+  }
+
+  fs::path const filename{"append_custom_timestamp_with_empty_locale_expansion.log"};
+  FileSinkConfig config;
+  config.set_timezone(Timezone::GmtTime);
+  config.set_filename_append_option(FilenameAppendOption::StartCustomTimestampFormat, "%p");
+
+  {
+    FileSink file_sink{filename, config};
+    REQUIRE(fs::exists(filename));
+  }
+
+  testing::remove_file(filename);
 }
 
 /***/


### PR DESCRIPTION
With `StartCustomTimestampFormat`, a valid format such as `%p` can expand to an empty string in locales without AM/PM markers. `FileSink` treats this as an insufficient buffer and eventually throws instead of opening the log file.

Prefix the format and remove the prefix from the result, as `StringFromTime` already does. Applies to both FileSink implementations.

The new regression fails before the fix. On Linux with `fr_FR.UTF-8`, all 77 FileSink/RotatingFileSink tests pass, as do the 23 FileSink tests with exceptions disabled.
